### PR TITLE
An API which Servo can implement

### DIFF
--- a/webxr-api/device.rs
+++ b/webxr-api/device.rs
@@ -16,8 +16,10 @@ use crate::Views;
 use euclid::Size2D;
 use euclid::TypedRigidTransform3D;
 
+use gleam::gl::GLsync;
+
 /// A trait for discovering XR devices
-pub trait Discovery: 'static {
+pub trait Discovery: 'static + Send {
     fn request_session(&mut self, mode: SessionMode, xr: SessionBuilder) -> Result<Session, Error>;
     fn supports_session(&self, mode: SessionMode) -> bool;
 }
@@ -36,6 +38,6 @@ pub trait Device {
 
     /// This method should render a GL texture to the device.
     /// While this method is being called, the device has unique access
-    /// to the texture.
-    fn render_animation_frame(&mut self, texture_id: u32, size: Size2D<i32>);
+    /// to the texture. The texture should be sync'd using glWaitSync before being used.
+    fn render_animation_frame(&mut self, texture_id: u32, size: Size2D<i32>, sync: GLsync);
 }

--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -7,6 +7,7 @@
 mod device;
 mod error;
 mod frame;
+mod registry;
 mod session;
 mod view;
 mod webgl;
@@ -17,6 +18,8 @@ pub use device::Discovery;
 pub use error::Error;
 
 pub use frame::Frame;
+
+pub use registry::Registry;
 
 pub use session::FrameRequestCallback;
 pub use session::HighResTimeStamp;
@@ -34,4 +37,4 @@ pub use view::View;
 pub use view::Viewer;
 pub use view::Views;
 
-pub use webgl::WebGLContextId;
+pub use webgl::WebGLExternalImageApi;

--- a/webxr-api/registry.rs
+++ b/webxr-api/registry.rs
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::Discovery;
+use crate::Error;
+use crate::Session;
+use crate::SessionBuilder;
+use crate::SessionMode;
+
+use std::sync::mpsc;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::Sender;
+use std::thread;
+
+#[derive(Clone)]
+pub struct Registry {
+    sender: Sender<RegistryMsg>,
+}
+
+pub struct RegistryThread {
+    discoveries: Vec<Box<dyn Discovery>>,
+    receiver: Receiver<RegistryMsg>,
+}
+
+pub type SessionSupportCallback = Box<dyn 'static + FnOnce(Result<(), Error>) + Send>;
+
+pub type SessionRequestCallback = Box<dyn 'static + FnOnce(Result<Session, Error>) + Send>;
+
+impl Registry {
+    pub fn new() -> Registry {
+        let (sender, receiver) = mpsc::channel();
+        let discoveries = Vec::new();
+        let mut thread = RegistryThread {
+            receiver,
+            discoveries,
+        };
+        let registry = Registry { sender };
+        thread::spawn(move || thread.run());
+        registry
+    }
+
+    pub fn register<D: Discovery>(&mut self, discovery: D) {
+        let _ = self.sender.send(RegistryMsg::Register(Box::new(discovery)));
+    }
+
+    pub fn supports_session(&mut self, mode: SessionMode, callback: SessionSupportCallback) {
+        let _ = self
+            .sender
+            .send(RegistryMsg::SupportsSession(mode, callback));
+    }
+
+    pub fn request_session(&mut self, mode: SessionMode, callback: SessionRequestCallback) {
+        let _ = self
+            .sender
+            .send(RegistryMsg::RequestSession(mode, callback));
+    }
+}
+
+impl RegistryThread {
+    fn run(&mut self) {
+        while let Ok(msg) = self.receiver.recv() {
+            match msg {
+                RegistryMsg::Register(discovery) => {
+                    self.discoveries.push(discovery);
+                }
+                RegistryMsg::SupportsSession(mode, callback) => {
+                    for discovery in &self.discoveries {
+                        if discovery.supports_session(mode) {
+                            return callback(Ok(()));
+                        }
+                    }
+                    return callback(Err(Error::NoMatchingDevice));
+                }
+                RegistryMsg::RequestSession(mode, callback) => {
+                    for discovery in &mut self.discoveries {
+                        let xr = SessionBuilder::new();
+                        if let Ok(session) = discovery.request_session(mode, xr) {
+                            return callback(Ok(session));
+                        }
+                    }
+                    return callback(Err(Error::NoMatchingDevice));
+                }
+            }
+        }
+    }
+}
+
+enum RegistryMsg {
+    Register(Box<dyn Discovery>),
+    RequestSession(SessionMode, SessionRequestCallback),
+    SupportsSession(SessionMode, SessionSupportCallback),
+}

--- a/webxr-api/session.rs
+++ b/webxr-api/session.rs
@@ -2,21 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::webgl::GLFactory;
-use crate::webgl::WebGLExternalImages;
 use crate::Device;
 use crate::Error;
 use crate::Floor;
 use crate::Frame;
 use crate::Native;
 use crate::Views;
-use crate::WebGLContextId;
+use crate::WebGLExternalImageApi;
 
 use euclid::TypedRigidTransform3D;
 
-use gleam::gl::Gl;
-
-use std::rc::Rc;
+use std::cell::Cell;
 use std::sync::mpsc;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
@@ -34,12 +30,13 @@ pub enum SessionMode {
 pub type HighResTimeStamp = f64;
 
 /// https://www.w3.org/TR/webxr/#callbackdef-xrframerequestcallback
-pub type FrameRequestCallback = Box<'static + FnOnce(HighResTimeStamp, Frame) + Send>;
+pub type FrameRequestCallback = Box<dyn 'static + FnOnce(HighResTimeStamp, Frame) + Send>;
 
 // The messages that are sent from the content thread to the session thread.
 enum SessionMsg {
+    UpdateWebGLExternalImageApi(Box<dyn WebGLExternalImageApi>),
     RequestAnimationFrame(FrameRequestCallback),
-    RenderAnimationFrame(WebGLContextId),
+    RenderAnimationFrame,
 }
 
 /// An object that represents an XR session.
@@ -60,14 +57,23 @@ impl Session {
         self.views.clone()
     }
 
+    pub fn update_webgl_external_image_api<I>(&mut self, images: I)
+    where
+        I: WebGLExternalImageApi,
+    {
+        let _ = self
+            .sender
+            .send(SessionMsg::UpdateWebGLExternalImageApi(Box::new(images)));
+    }
+
     pub fn request_animation_frame(&mut self, callback: FrameRequestCallback) {
         let _ = self
             .sender
             .send(SessionMsg::RequestAnimationFrame(callback));
     }
 
-    pub fn render_animation_frame(&mut self, webgl: WebGLContextId) {
-        let _ = self.sender.send(SessionMsg::RenderAnimationFrame(webgl));
+    pub fn render_animation_frame(&mut self) {
+        let _ = self.sender.send(SessionMsg::RenderAnimationFrame);
     }
 }
 
@@ -75,7 +81,7 @@ impl Session {
 pub struct SessionThread<D> {
     receiver: Receiver<SessionMsg>,
     sender: Sender<SessionMsg>,
-    images: WebGLExternalImages,
+    images: Option<Box<dyn WebGLExternalImageApi>>,
     timestamp: HighResTimeStamp,
     device: D,
 }
@@ -95,16 +101,22 @@ impl<D: Device> SessionThread<D> {
     pub fn run(&mut self) {
         while let Ok(msg) = self.receiver.recv() {
             match msg {
+                SessionMsg::UpdateWebGLExternalImageApi(images) => {
+                    self.images = Some(images);
+                }
                 SessionMsg::RequestAnimationFrame(callback) => {
                     let timestamp = self.timestamp;
                     let frame = self.device.wait_for_animation_frame();
                     self.timestamp += 1.0;
                     callback(timestamp, frame);
                 }
-                SessionMsg::RenderAnimationFrame(ctx) => {
-                    let (texture_id, size) = self.images.lock(ctx);
-                    self.device.render_animation_frame(texture_id, size);
-                    self.images.unlock(ctx);
+                SessionMsg::RenderAnimationFrame => {
+                    if let Some(ref images) = self.images {
+                        if let Ok((texture_id, size, sync)) = images.lock() {
+                            self.device.render_animation_frame(texture_id, size, sync);
+                            images.unlock();
+                        }
+                    }
                 }
             }
         }
@@ -112,19 +124,25 @@ impl<D: Device> SessionThread<D> {
 }
 
 /// A type for building XR sessions
-#[derive(Clone)]
 pub struct SessionBuilder {
-    images: WebGLExternalImages,
-    gl_factory: GLFactory,
+    // This field is just used to make the type !Sync and !Send, for futureproofing
+    #[allow(dead_code)]
+    not_sync_or_send: Cell<()>,
 }
 
 impl SessionBuilder {
+    pub(crate) fn new() -> SessionBuilder {
+        SessionBuilder {
+            not_sync_or_send: Cell::new(()),
+        }
+    }
+
     /// For devices which want to do their own thread management,
     /// e.g. where the session thread has to be run on the main thread.
     pub fn new_thread<D: Device>(self, device: D) -> SessionThread<D> {
         let (sender, receiver) = mpsc::channel();
-        let images = self.images.clone();
         let timestamp = 0.0;
+        let images = None;
         SessionThread {
             sender,
             receiver,
@@ -153,9 +171,5 @@ impl SessionBuilder {
             }
         });
         ackr.recv().unwrap_or(Err(Error::CommunicationError))
-    }
-
-    pub fn gl(&mut self) -> Rc<Gl> {
-        self.gl_factory.build()
     }
 }

--- a/webxr-api/webgl.rs
+++ b/webxr-api/webgl.rs
@@ -4,40 +4,17 @@
 
 //! The WebGL functionality needed by WebXR.
 
+use crate::Error;
 use euclid::Size2D;
-use gleam::gl::Gl;
-use std::rc::Rc;
+use gleam::gl::GLsync;
+use gleam::gl::GLuint;
 
-/// An identifier for a WebGL context.
-// TODO: refactor the Servo webgl_traits crate to support sharing this type.
-#[derive(Copy, Clone, Debug)]
-pub struct WebGLContextId(pub usize);
+/// A trait to get access a GL texture from a WebGL context.
+pub trait WebGLExternalImageApi: 'static + Send {
+    /// Lock the WebGL context, and get back a texture id, the size of the texture,
+    /// and a sync object for the texture.
+    fn lock(&self) -> Result<(GLuint, Size2D<i32>, GLsync), Error>;
 
-/// A type to get access to a GL texture from a WebGL context.
-// TODO: refactor the Servo canvas crate to support sharing this type.
-#[derive(Clone)]
-pub struct WebGLExternalImages(());
-
-/// https://github.com/servo/servo/blob/123f58592c9bedae735a84fe5c93b0a20292ea86/components/canvas/webgl_thread.rs#L733-L742
-impl WebGLExternalImages {
-    // TODO: implement this
-    pub fn lock(&mut self, _: WebGLContextId) -> (u32, Size2D<i32>) {
-        unimplemented!();
-    }
-
-    // TODO: implement this
-    pub fn unlock(&mut self, _: WebGLContextId) {
-        unimplemented!()
-    }
-}
-
-/// A factory for building GL objects.
-// TODO refactor the Servo canvas crate to support sharing this type
-#[derive(Clone)]
-pub struct GLFactory(());
-
-impl GLFactory {
-    pub fn build(&mut self) -> Rc<Gl> {
-        unimplemented!()
-    }
+    /// Unlock the WebGL context.
+    fn unlock(&self);
 }


### PR DESCRIPTION
Some changes to the API for compatibility with Servo:

* Add a device registry API
* Make the WebGL external images API compatible with Servo's `WebGLMsgSender`
* Bind the images API after creation, since this is what WebXR does
* Remove `GLFactory` since Servo doesn't have one of those, it has a `GLContextFactory` which builds a context, not just binds the GL API

