### PR TITLE
Support devices which have main thread affinity

### DIFF
--- a/webxr-api/device.rs
+++ b/webxr-api/device.rs
@@ -26,7 +26,7 @@ pub trait Discovery: 'static + Send {
 }
 
 /// A trait for using an XR device
-pub trait Device {
+pub trait Device: 'static {
     /// The transform from native coordinates to the floor.
     fn floor_transform(&self) -> TypedRigidTransform3D<f32, Native, Floor>;
 

--- a/webxr-api/device.rs
+++ b/webxr-api/device.rs
@@ -20,7 +20,7 @@ use gleam::gl::GLsync;
 
 /// A trait for discovering XR devices
 #[cfg_attr(feature = "ipc", typetag::serde)]
-pub trait Discovery: 'static + Send {
+pub trait Discovery: 'static {
     fn request_session(&mut self, mode: SessionMode, xr: SessionBuilder) -> Result<Session, Error>;
     fn supports_session(&self, mode: SessionMode) -> bool;
 }

--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -19,10 +19,12 @@ pub use error::Error;
 
 pub use frame::Frame;
 
+pub use registry::MainThreadRegistry;
 pub use registry::Registry;
 
 pub use session::FrameRequestCallback;
 pub use session::HighResTimeStamp;
+pub use session::MainThreadSession;
 pub use session::Session;
 pub use session::SessionBuilder;
 pub use session::SessionMode;


### PR DESCRIPTION
Run the XR registry on the main thread, which allows devices which have main-thread affinity to be implemented without using `Send`.