### PR TITLE
Add support for mock XR devices

### DIFF
--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -7,6 +7,7 @@
 mod device;
 mod error;
 mod frame;
+mod mock;
 mod registry;
 mod session;
 mod view;
@@ -18,6 +19,10 @@ pub use device::Discovery;
 pub use error::Error;
 
 pub use frame::Frame;
+
+pub use mock::MockDeviceInit;
+pub use mock::MockDeviceMsg;
+pub use mock::MockDiscovery;
 
 pub use registry::MainThreadRegistry;
 pub use registry::Registry;

--- a/webxr-api/mock.rs
+++ b/webxr-api/mock.rs
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::Discovery;
+use crate::Error;
+use crate::Floor;
+use crate::Native;
+use crate::Receiver;
+use crate::Viewer;
+use crate::Views;
+
+use euclid::TypedRigidTransform3D;
+
+#[cfg(feature = "ipc")]
+use serde::{Deserialize, Serialize};
+
+/// A trait for discovering mock XR devices
+pub trait MockDiscovery: 'static {
+    fn simulate_device_connection(
+        &mut self,
+        init: MockDeviceInit,
+        receiver: Receiver<MockDeviceMsg>,
+    ) -> Result<Box<dyn Discovery>, Error>;
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+pub struct MockDeviceInit {
+    pub local_to_floor_level_transform: TypedRigidTransform3D<f32, Viewer, Floor>,
+    pub supports_immersive: bool,
+    pub supports_unbounded: bool,
+    pub viewer_origin: TypedRigidTransform3D<f32, Native, Viewer>,
+    pub views: Views,
+}
+
+#[derive(Debug)]
+#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+pub enum MockDeviceMsg {
+    SetViewerOrigin(TypedRigidTransform3D<f32, Native, Viewer>),
+    SetViews(Views),
+    Focus,
+    Blur,
+}

--- a/webxr-api/registry.rs
+++ b/webxr-api/registry.rs
@@ -5,6 +5,9 @@
 use crate::Discovery;
 use crate::Error;
 use crate::MainThreadSession;
+use crate::MockDeviceInit;
+use crate::MockDeviceMsg;
+use crate::MockDiscovery;
 use crate::Receiver;
 use crate::Sender;
 use crate::Session;
@@ -23,6 +26,7 @@ pub struct Registry {
 pub struct MainThreadRegistry {
     discoveries: Vec<Box<dyn Discovery>>,
     sessions: Vec<Box<dyn MainThreadSession>>,
+    mocks: Vec<Box<dyn MockDiscovery>>,
     sender: Sender<RegistryMsg>,
     receiver: Receiver<RegistryMsg>,
 }
@@ -35,6 +39,11 @@ pub trait SessionSupportCallback: 'static + Send {
 #[cfg_attr(feature = "ipc", typetag::serde)]
 pub trait SessionRequestCallback: 'static + Send {
     fn callback(&mut self, result: Result<Session, Error>);
+}
+
+#[cfg_attr(feature = "ipc", typetag::serde)]
+pub trait MockDeviceCallback: 'static + Send {
+    fn callback(&mut self, result: Result<Sender<MockDeviceMsg>, Error>);
 }
 
 impl Registry {
@@ -55,6 +64,16 @@ impl Registry {
             .sender
             .send(RegistryMsg::RequestSession(mode, Box::new(callback)));
     }
+
+    pub fn simulate_device_connection<C>(&mut self, init: MockDeviceInit, callback: C)
+    where
+        C: MockDeviceCallback,
+    {
+        let _ = self.sender.send(RegistryMsg::SimulateDeviceConnection(
+            init,
+            Box::new(callback),
+        ));
+    }
 }
 
 impl MainThreadRegistry {
@@ -62,9 +81,11 @@ impl MainThreadRegistry {
         let (sender, receiver) = crate::channel().or(Err(Error::CommunicationError))?;
         let discoveries = Vec::new();
         let sessions = Vec::new();
+        let mocks = Vec::new();
         Ok(MainThreadRegistry {
             discoveries,
             sessions,
+            mocks,
             sender,
             receiver,
         })
@@ -78,6 +99,10 @@ impl MainThreadRegistry {
 
     pub fn register<D: Discovery>(&mut self, discovery: D) {
         self.discoveries.push(Box::new(discovery));
+    }
+
+    pub fn register_mock<D: MockDiscovery>(&mut self, discovery: D) {
+        self.mocks.push(Box::new(discovery));
     }
 
     pub fn run_on_main_thread<S: MainThreadSession>(&mut self, session: S) {
@@ -101,23 +126,48 @@ impl MainThreadRegistry {
     fn handle_msg(&mut self, msg: RegistryMsg) {
         match msg {
             RegistryMsg::SupportsSession(mode, mut callback) => {
-                for discovery in &self.discoveries {
-                    if discovery.supports_session(mode) {
-                        return callback.callback(Ok(()));
-                    }
-                }
-                return callback.callback(Err(Error::NoMatchingDevice));
+                callback.callback(self.supports_session(mode));
             }
             RegistryMsg::RequestSession(mode, mut callback) => {
-                for discovery in &mut self.discoveries {
-                    let xr = SessionBuilder::new(&mut self.sessions);
-                    if let Ok(session) = discovery.request_session(mode, xr) {
-                        return callback.callback(Ok(session));
-                    }
-                }
-                return callback.callback(Err(Error::NoMatchingDevice));
+                callback.callback(self.request_session(mode));
+            }
+            RegistryMsg::SimulateDeviceConnection(init, mut callback) => {
+                callback.callback(self.simulate_device_connection(init));
             }
         }
+    }
+
+    fn supports_session(&mut self, mode: SessionMode) -> Result<(), Error> {
+        for discovery in &self.discoveries {
+            if discovery.supports_session(mode) {
+                return Ok(());
+            }
+        }
+        Err(Error::NoMatchingDevice)
+    }
+
+    fn request_session(&mut self, mode: SessionMode) -> Result<Session, Error> {
+        for discovery in &mut self.discoveries {
+            let xr = SessionBuilder::new(&mut self.sessions);
+            if let Ok(session) = discovery.request_session(mode, xr) {
+                return Ok(session);
+            }
+        }
+        Err(Error::NoMatchingDevice)
+    }
+
+    fn simulate_device_connection(
+        &mut self,
+        init: MockDeviceInit,
+    ) -> Result<Sender<MockDeviceMsg>, Error> {
+        for mock in &mut self.mocks {
+            let (sender, receiver) = crate::channel().or(Err(Error::CommunicationError))?;
+            if let Ok(discovery) = mock.simulate_device_connection(init.clone(), receiver) {
+                self.discoveries.insert(0, discovery);
+                return Ok(sender);
+            }
+        }
+        Err(Error::NoMatchingDevice)
     }
 }
 
@@ -125,4 +175,5 @@ impl MainThreadRegistry {
 enum RegistryMsg {
     RequestSession(SessionMode, Box<dyn SessionRequestCallback>),
     SupportsSession(SessionMode, Box<dyn SessionSupportCallback>),
+    SimulateDeviceConnection(MockDeviceInit, Box<dyn MockDeviceCallback>),
 }

--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -20,6 +20,7 @@ path = "lib.rs"
 
 [features]
 glwindow = ["glutin"]
+headless = []
 ipc = ["webxr-api/ipc"]
 
 [dependencies]

--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use webxr_api::Device;
+use webxr_api::Discovery;
+use webxr_api::Error;
+use webxr_api::Floor;
+use webxr_api::Frame;
+use webxr_api::MockDeviceInit;
+use webxr_api::MockDeviceMsg;
+use webxr_api::MockDiscovery;
+use webxr_api::Native;
+use webxr_api::Receiver;
+use webxr_api::Session;
+use webxr_api::SessionBuilder;
+use webxr_api::SessionMode;
+use webxr_api::Viewer;
+use webxr_api::Views;
+
+use euclid::Size2D;
+use euclid::TypedRigidTransform3D;
+
+use gleam::gl::GLsync;
+use gleam::gl::GLuint;
+
+pub struct HeadlessMockDiscovery(());
+
+struct HeadlessDiscovery {
+    init: MockDeviceInit,
+    receiver: Option<Receiver<MockDeviceMsg>>,
+}
+
+struct HeadlessDevice {
+    floor_transform: TypedRigidTransform3D<f32, Native, Floor>,
+    viewer_origin: TypedRigidTransform3D<f32, Native, Viewer>,
+    views: Views,
+    receiver: Receiver<MockDeviceMsg>,
+}
+
+impl MockDiscovery for HeadlessMockDiscovery {
+    fn simulate_device_connection(
+        &mut self,
+        init: MockDeviceInit,
+        receiver: Receiver<MockDeviceMsg>,
+    ) -> Result<Box<dyn Discovery>, Error> {
+        Ok(Box::new(HeadlessDiscovery {
+            init,
+            receiver: Some(receiver),
+        }))
+    }
+}
+
+impl Discovery for HeadlessDiscovery {
+    fn request_session(&mut self, mode: SessionMode, xr: SessionBuilder) -> Result<Session, Error> {
+        if !self.supports_session(mode) {
+            return Err(Error::NoMatchingDevice);
+        }
+        let receiver = self.receiver.take().ok_or(Error::NoMatchingDevice)?;
+        let viewer_origin = self.init.viewer_origin.clone();
+        let floor_transform = self
+            .init
+            .local_to_floor_level_transform
+            .pre_mul(&viewer_origin);
+        let views = self.init.views.clone();
+        xr.spawn(move || {
+            Ok(HeadlessDevice {
+                floor_transform,
+                viewer_origin,
+                views,
+                receiver,
+            })
+        })
+    }
+
+    fn supports_session(&self, mode: SessionMode) -> bool {
+        mode == SessionMode::Inline || self.init.supports_immersive
+    }
+}
+
+impl Device for HeadlessDevice {
+    fn floor_transform(&self) -> TypedRigidTransform3D<f32, Native, Floor> {
+        self.floor_transform.clone()
+    }
+
+    fn views(&self) -> Views {
+        self.views.clone()
+    }
+
+    fn wait_for_animation_frame(&mut self) -> Frame {
+        while let Ok(msg) = self.receiver.try_recv() {
+            self.handle_msg(msg);
+        }
+        let transform = self.viewer_origin.inverse();
+        Frame { transform }
+    }
+
+    fn render_animation_frame(&mut self, _: GLuint, _: Size2D<i32>, _: GLsync) {}
+}
+
+impl HeadlessDevice {
+    fn handle_msg(&mut self, msg: MockDeviceMsg) {
+        match msg {
+            MockDeviceMsg::SetViewerOrigin(viewer_origin) => {
+                self.viewer_origin = viewer_origin;
+            }
+            MockDeviceMsg::SetViews(views) => {
+                self.views = views;
+            }
+            MockDeviceMsg::Focus => {
+                // TODO
+            }
+            MockDeviceMsg::Blur => {
+                // TODO
+            }
+        }
+    }
+}

--- a/webxr/lib.rs
+++ b/webxr/lib.rs
@@ -6,3 +6,6 @@
 
 #[cfg(feature = "glwindow")]
 pub mod glwindow;
+
+#[cfg(feature = "headless")]
+pub mod headless;


### PR DESCRIPTION
This PR adds a frist-cut API for mocking, and a headless implementation. It's based on the webxr-test API (https://github.com/immersive-web/webxr-test-api/) and the rust-webvr mock API (https://github.com/servo/rust-webvr/blob/master/rust-webvr-api/src/mock.rs).