### PR TITLE
 Devices provide a recommended device resolution 

### DIFF
--- a/webxr-api/device.rs
+++ b/webxr-api/device.rs
@@ -12,10 +12,12 @@ use crate::Native;
 use crate::Session;
 use crate::SessionBuilder;
 use crate::SessionMode;
+use crate::Viewport;
 use crate::Views;
 
 use euclid::Size2D;
 use euclid::TypedRigidTransform3D;
+use euclid::TypedSize2D;
 
 use gleam::gl::GLsync;
 
@@ -30,8 +32,18 @@ pub trait Device: 'static {
     /// The transform from native coordinates to the floor.
     fn floor_transform(&self) -> TypedRigidTransform3D<f32, Native, Floor>;
 
-    /// The transforms from viewer coordinates to the eyes.
+    /// The transforms from viewer coordinates to the eyes, and their associated viewports.
     fn views(&self) -> Views;
+
+    /// A resolution large enough to contain all the viewports.
+    /// https://immersive-web.github.io/webxr/#native-webgl-framebuffer-resolution
+    fn recommended_framebuffer_resolution(&self) -> TypedSize2D<i32, Viewport> {
+        let viewport = match self.views() {
+            Views::Mono(view) => view.viewport,
+            Views::Stereo(left, right) => left.viewport.union(&right.viewport),
+        };
+        TypedSize2D::new(viewport.max_x(), viewport.max_y())
+    }
 
     /// This method should block waiting for the next frame,
     /// and return the information for it.

--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -51,6 +51,7 @@ pub use view::Native;
 pub use view::RightEye;
 pub use view::View;
 pub use view::Viewer;
+pub use view::Viewport;
 pub use view::Views;
 
 pub use webgl::WebGLExternalImageApi;

--- a/webxr-api/session.rs
+++ b/webxr-api/session.rs
@@ -10,10 +10,12 @@ use crate::InputSource;
 use crate::Native;
 use crate::Receiver;
 use crate::Sender;
+use crate::Viewport;
 use crate::Views;
 use crate::WebGLExternalImageApi;
 
 use euclid::TypedRigidTransform3D;
+use euclid::TypedSize2D;
 
 use std::thread;
 use std::time::Duration;
@@ -58,6 +60,7 @@ enum SessionMsg {
 pub struct Session {
     floor_transform: TypedRigidTransform3D<f32, Native, Floor>,
     views: Views,
+    resolution: TypedSize2D<i32, Viewport>,
     sender: Sender<SessionMsg>,
     initial_inputs: Vec<InputSource>,
 }
@@ -73,6 +76,10 @@ impl Session {
 
     pub fn views(&self) -> Views {
         self.views.clone()
+    }
+
+    pub fn recommended_framebuffer_resolution(&self) -> TypedSize2D<i32, Viewport> {
+        self.resolution
     }
 
     pub fn update_webgl_external_image_api<I>(&mut self, images: I)
@@ -131,11 +138,13 @@ impl<D: Device> SessionThread<D> {
     pub fn new_session(&mut self) -> Session {
         let floor_transform = self.device.floor_transform();
         let views = self.device.views();
+        let resolution = self.device.recommended_framebuffer_resolution();
         let sender = self.sender.clone();
         let initial_inputs = self.device.initial_inputs();
         Session {
             floor_transform,
             views,
+            resolution,
             sender,
             initial_inputs,
         }

--- a/webxr/glwindow/mod.rs
+++ b/webxr/glwindow/mod.rs
@@ -154,7 +154,7 @@ impl Device for GlWindowDevice {
 }
 
 impl GlWindowDevice {
-    fn new(gl: Rc<dyn Gl>, mut window: Box<GlWindow>) -> Result<GlWindowDevice, Error> {
+    fn new(gl: Rc<dyn Gl>, mut window: Box<dyn GlWindow>) -> Result<GlWindowDevice, Error> {
         window.make_current();
         let read_fbo = gl.gen_framebuffers(1)[0];
         debug_assert_eq!(gl.get_error(), gl::NO_ERROR);


### PR DESCRIPTION
Devices can provide their recommended resolution (by default, large enough to hold all the viewports).