### PR TITLE
Add a main thread waker

### DIFF
--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -40,6 +40,7 @@ pub use mock::MockInputInit;
 pub use mock::MockInputMsg;
 
 pub use registry::MainThreadRegistry;
+pub use registry::MainThreadWaker;
 pub use registry::Registry;
 pub use registry::{MockDeviceCallback, SessionRequestCallback, SessionSupportCallback};
 


### PR DESCRIPTION
This PR adds a callback which can be called from any process to wake up the main thead. It's needed because of servo embeddings like glutin, where the main thread can be blocked waiting for UI events, and not listening for events from servo.