### PR TITLE
Make GLsync object optional

### DIFF
--- a/webxr-api/device.rs
+++ b/webxr-api/device.rs
@@ -55,7 +55,12 @@ pub trait Device: 'static {
     /// This method should render a GL texture to the device.
     /// While this method is being called, the device has unique access
     /// to the texture. The texture should be sync'd using glWaitSync before being used.
-    fn render_animation_frame(&mut self, texture_id: u32, size: UntypedSize2D<i32>, sync: GLsync);
+    fn render_animation_frame(
+        &mut self,
+        texture_id: u32,
+        size: UntypedSize2D<i32>,
+        sync: Option<GLsync>,
+    );
 
     /// Inputs registered with the device on initialization. More may be added, which
     /// should be communicated through a yet-undecided event mechanism

--- a/webxr-api/webgl.rs
+++ b/webxr-api/webgl.rs
@@ -18,7 +18,7 @@ pub type WebGLTextureId = GLuint;
 // the matching webrender trait.
 pub trait WebGLExternalImageApi: Send {
     /// Lock the WebGL context, and get back a sync object for its current state.
-    fn lock(&self, id: WebGLContextId) -> GLsync;
+    fn lock(&self, id: WebGLContextId) -> Option<GLsync>;
 
     /// Unlock the WebGL context.
     fn unlock(&self, id: WebGLContextId);

--- a/webxr/glwindow/mod.rs
+++ b/webxr/glwindow/mod.rs
@@ -112,7 +112,12 @@ impl Device for GlWindowDevice {
         }
     }
 
-    fn render_animation_frame(&mut self, texture_id: u32, size: UntypedSize2D<i32>, sync: GLsync) {
+    fn render_animation_frame(
+        &mut self,
+        texture_id: u32,
+        size: UntypedSize2D<i32>,
+        sync: Option<GLsync>,
+    ) {
         self.window.make_current();
 
         let width = size.width as GLsizei;
@@ -121,8 +126,12 @@ impl Device for GlWindowDevice {
 
         self.gl.clear_color(0.2, 0.3, 0.3, 1.0);
         self.gl.clear(gl::COLOR_BUFFER_BIT);
-        self.gl.wait_sync(sync, 0, gl::TIMEOUT_IGNORED);
         debug_assert_eq!(self.gl.get_error(), gl::NO_ERROR);
+
+        if let Some(sync) = sync {
+            self.gl.wait_sync(sync, 0, gl::TIMEOUT_IGNORED);
+            debug_assert_eq!(self.gl.get_error(), gl::NO_ERROR);
+        }
 
         self.gl
             .bind_framebuffer(gl::READ_FRAMEBUFFER, self.read_fbo);

--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -148,8 +148,11 @@ impl Device for HeadlessDevice {
         Frame { transform, inputs }
     }
 
-    fn render_animation_frame(&mut self, _: GLuint, _: Size2D<i32>, sync: GLsync) {
-        self.gl.wait_sync(sync, 0, gl::TIMEOUT_IGNORED);
+    fn render_animation_frame(&mut self, _: GLuint, _: Size2D<i32>, sync: Option<GLsync>) {
+        if let Some(sync) = sync {
+            self.gl.wait_sync(sync, 0, gl::TIMEOUT_IGNORED);
+            debug_assert_eq!(self.gl.get_error(), gl::NO_ERROR);
+        }
     }
 
     fn initial_inputs(&self) -> Vec<InputSource> {


### PR DESCRIPTION
If a webxr device and webgl are both running on the same thread, then there's no need for a GLsync object.