### PR TITLE
Copy pixels to d3d texture in openxr backend

### DIFF
--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -10,11 +10,11 @@ use gleam::gl::{self, GLsync, GLuint, Gl};
 use openxr::d3d::{Requirements, SessionCreateInfo, D3D11};
 use openxr::sys::platform::ID3D11Device;
 use openxr::{
-    self, ApplicationInfo, CompositionLayerProjection, Entry, EnvironmentBlendMode, ExtensionSet,
-    Extent2Di, FormFactor, Fovf, FrameState, FrameStream, FrameWaiter, Graphics, Instance, Posef,
-    Quaternionf, ReferenceSpaceType, Session, Space, Swapchain, SwapchainCreateFlags,
-    SwapchainCreateInfo, SwapchainUsageFlags, Vector3f, ViewConfigurationType,
-    ViewConfigurationView,
+    self, ApplicationInfo, CompositionLayerFlags, CompositionLayerProjection, Entry,
+    EnvironmentBlendMode, ExtensionSet, Extent2Di, FormFactor, Fovf, FrameState, FrameStream,
+    FrameWaiter, Graphics, Instance, Posef, Quaternionf, ReferenceSpaceType, Session, Space,
+    Swapchain, SwapchainCreateFlags, SwapchainCreateInfo, SwapchainUsageFlags, Vector3f,
+    ViewConfigurationType, ViewConfigurationView,
 };
 use std::rc::Rc;
 use std::{mem, ptr};
@@ -472,6 +472,7 @@ impl Device for OpenXrDevice {
                 EnvironmentBlendMode::ADDITIVE,
                 &[&CompositionLayerProjection::new()
                     .space(&self.space)
+                    .layer_flags(CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA)
                     .views(&[
                         openxr::CompositionLayerProjectionView::new()
                             .pose(self.openxr_views[0].pose)

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -339,6 +339,9 @@ impl Device for OpenXrDevice {
             }
             flipped
         }
+        if let Some(sync) = sync {
+            self.gl.wait_sync(sync, 0, gl::TIMEOUT_IGNORED);
+        }
         let fb = self.read_fbo;
         self.gl.bind_framebuffer(gl::FRAMEBUFFER, fb);
         self.gl.bind_texture(gl::TEXTURE_2D, texture_id);
@@ -502,9 +505,6 @@ impl Device for OpenXrDevice {
                     ])],
             )
             .unwrap();
-        if let Some(sync) = sync {
-            self.gl.wait_sync(sync, 0, gl::TIMEOUT_IGNORED);
-        }
     }
 
     fn initial_inputs(&self) -> Vec<InputSource> {
@@ -588,7 +588,8 @@ fn init_device_for_adapter(
             adapter.as_raw(),
             D3D_DRIVER_TYPE_UNKNOWN,
             ptr::null_mut(),
-            d3d11::D3D11_CREATE_DEVICE_BGRA_SUPPORT | d3d11::D3D11_CREATE_DEVICE_DEBUG,
+            // add d3d11::D3D11_CREATE_DEVICE_DEBUG below for debug output
+            d3d11::D3D11_CREATE_DEVICE_BGRA_SUPPORT,
             feature_levels.as_ptr(),
             feature_levels.len() as u32,
             d3d11::D3D11_SDK_VERSION,


### PR DESCRIPTION
This is inefficient, but it works.

We should figure out ANGLE sharing to do a direct blit, next.


r? @jdm 