### PR TITLE
Allow immersive VR sessions in OpenXR backend

### DIFF
--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -93,7 +93,7 @@ impl Discovery for OpenXrDiscovery {
     }
 
     fn supports_session(&self, mode: SessionMode) -> bool {
-        mode == SessionMode::ImmersiveAR
+        mode == SessionMode::ImmersiveAR || mode == SessionMode::ImmersiveVR
     }
 }
 


### PR DESCRIPTION
This allows testing out a bunch of existing three.js content in AR headsets.