### PR TITLE
request openxr shutdown on quit

### DIFF
--- a/webxr-api/session.rs
+++ b/webxr-api/session.rs
@@ -237,7 +237,7 @@ impl<D: Device> MainThreadSession for SessionThread<D> {
         let timestamp = self.timestamp;
         while timestamp == self.timestamp && self.running {
             if let Ok(msg) = crate::recv_timeout(&self.receiver, TIMEOUT) {
-                self.handle_msg(msg);
+                self.running = self.handle_msg(msg);
             } else {
                 break;
             }

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -523,6 +523,7 @@ impl Device for OpenXrDevice {
 
     fn quit(&mut self) {
         self.events.callback(Event::SessionEnd);
+        self.session.request_exit();
     }
 
     fn set_quitter(&mut self, _: Quitter) {


### PR DESCRIPTION
This will end the openxr session (back to 2D view in the case of HoloLens).

It's still missing the call to `session.end()` (see #47).

Fix #48 