### PR TITLE
Asynchonous shutdown

### DIFF
--- a/webxr-api/device.rs
+++ b/webxr-api/device.rs
@@ -48,6 +48,10 @@ pub trait Device: 'static {
         Size2D::new(viewport.max_x(), viewport.max_y())
     }
 
+    /// This method checks if the session has exited since last
+    /// wait_for_animation_frame call.
+    fn is_running(&self) -> bool;
+
     /// This method should block waiting for the next frame,
     /// and return the information for it.
     fn wait_for_animation_frame(&mut self) -> Frame;

--- a/webxr-api/session.rs
+++ b/webxr-api/session.rs
@@ -205,8 +205,12 @@ impl<D: Device> SessionThread<D> {
             }
             SessionMsg::RequestAnimationFrame(dest) => {
                 let timestamp = self.timestamp;
-                let frame = self.device.wait_for_animation_frame();
-                let _ = dest.send((timestamp, frame));
+                if self.device.is_running() {
+                    let frame = self.device.wait_for_animation_frame();
+                    let _ = dest.send((timestamp, frame));
+                } else {
+                    return false;
+                }
             }
             SessionMsg::UpdateClipPlanes(near, far) => self.device.update_clip_planes(near, far),
             SessionMsg::RenderAnimationFrame => {
@@ -219,7 +223,6 @@ impl<D: Device> SessionThread<D> {
             }
             SessionMsg::Quit => {
                 self.device.quit();
-                return false;
             }
         }
         true

--- a/webxr/glwindow/mod.rs
+++ b/webxr/glwindow/mod.rs
@@ -89,6 +89,7 @@ pub struct GlWindowDevice {
     read_fbo: GLuint,
     events: EventBuffer,
     clip_planes: ClipPlanes,
+    is_running: bool,
 }
 
 impl Device for GlWindowDevice {
@@ -177,7 +178,12 @@ impl Device for GlWindowDevice {
         self.events.upgrade(dest)
     }
 
+    fn is_running(&self) -> bool {
+        self.is_running
+    }
+
     fn quit(&mut self) {
+        self.is_running = false;
         self.events.callback(Event::SessionEnd);
     }
 
@@ -204,6 +210,7 @@ impl GlWindowDevice {
             read_fbo,
             events: Default::default(),
             clip_planes: Default::default(),
+            is_running: true,
         })
     }
 

--- a/webxr/googlevr/device.rs
+++ b/webxr/googlevr/device.rs
@@ -63,6 +63,7 @@ pub(crate) struct GoogleVRDevice {
     depth: bool,
     clip_planes: ClipPlanes,
     input: Option<GoogleVRController>,
+    is_running: bool,
 
     #[cfg(target_os = "android")]
     java_class: ndk::jclass,
@@ -98,6 +99,7 @@ impl GoogleVRDevice {
             depth: false,
             clip_planes: Default::default(),
             input: None,
+            is_running: true,
 
             ctx: ctx.get(),
             controller_ctx: controller_ctx.get(),
@@ -139,6 +141,7 @@ impl GoogleVRDevice {
             depth: false,
             clip_planes: Default::default(),
             input: None,
+            is_running: true,
 
             ctx: ctx.get(),
             controller_ctx: controller_ctx.get(),
@@ -579,9 +582,14 @@ impl Device for GoogleVRDevice {
         self.events.upgrade(dest);
     }
 
+    fn is_running(&self) -> bool {
+        self.is_running
+    }
+
     fn quit(&mut self) {
         self.stop_present();
         self.events.callback(Event::SessionEnd);
+        self.is_running = false;
     }
 
     fn set_quitter(&mut self, _: Quitter) {

--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -58,6 +58,7 @@ struct InputInfo {
 struct HeadlessDevice {
     gl: Rc<dyn Gl>,
     data: Arc<Mutex<HeadlessDeviceData>>,
+    is_running: bool,
 }
 
 struct HeadlessDeviceData {
@@ -119,7 +120,13 @@ impl Discovery for HeadlessDiscovery {
         }
         let gl = self.gl.clone();
         let data = self.data.clone();
-        xr.run_on_main_thread(move || Ok(HeadlessDevice { gl, data }))
+        xr.run_on_main_thread(move || {
+            Ok(HeadlessDevice {
+                gl,
+                data,
+                is_running: true,
+            })
+        })
     }
 
     fn supports_session(&self, mode: SessionMode) -> bool {
@@ -177,7 +184,12 @@ impl Device for HeadlessDevice {
         self.data.lock().unwrap().events.upgrade(dest)
     }
 
+    fn is_running(&self) -> bool {
+        self.is_running
+    }
+
     fn quit(&mut self) {
+        self.is_running = false;
         self.data.lock().unwrap().events.callback(Event::SessionEnd);
     }
 

--- a/webxr/magicleap/mod.rs
+++ b/webxr/magicleap/mod.rs
@@ -98,6 +98,7 @@ pub struct MagicLeapDevice {
     frame_handle: MLHandle,
     cameras: MLGraphicsVirtualCameraInfoArray,
     view_update_needed: bool,
+    is_running: bool,
 }
 
 impl MagicLeapDiscovery {
@@ -442,7 +443,12 @@ impl Device for MagicLeapDevice {
         // TODO: handle events
     }
 
+    fn is_running(&self) -> bool {
+        self.is_running
+    }
+
     fn quit(&mut self) {
+        self.is_running = false;
         // TODO: handle quit
     }
 


### PR DESCRIPTION
OpenXR shuts down asynchronously.

Ideally webxr would intercept the `SessionEnd` event. But for now, I think this will do.