### PR TITLE
More shutdown event processing

### DIFF
--- a/webxr-api/device.rs
+++ b/webxr-api/device.rs
@@ -48,13 +48,9 @@ pub trait Device: 'static {
         Size2D::new(viewport.max_x(), viewport.max_y())
     }
 
-    /// This method checks if the session has exited since last
-    /// wait_for_animation_frame call.
-    fn is_running(&self) -> bool;
-
     /// This method should block waiting for the next frame,
     /// and return the information for it.
-    fn wait_for_animation_frame(&mut self) -> Frame;
+    fn wait_for_animation_frame(&mut self) -> Option<Frame>;
 
     /// This method should render a GL texture to the device.
     /// While this method is being called, the device has unique access

--- a/webxr-api/session.rs
+++ b/webxr-api/session.rs
@@ -205,12 +205,14 @@ impl<D: Device> SessionThread<D> {
             }
             SessionMsg::RequestAnimationFrame(dest) => {
                 let timestamp = self.timestamp;
-                if self.device.is_running() {
-                    let frame = self.device.wait_for_animation_frame();
-                    let _ = dest.send((timestamp, frame));
-                } else {
-                    return false;
-                }
+                match self.device.wait_for_animation_frame() {
+                    Some(frame) => {
+                        let _ = dest.send((timestamp, frame));
+                    }
+                    None => {
+                        return false;
+                    }
+                };
             }
             SessionMsg::UpdateClipPlanes(near, far) => self.device.update_clip_planes(near, far),
             SessionMsg::RenderAnimationFrame => {

--- a/webxr/glwindow/mod.rs
+++ b/webxr/glwindow/mod.rs
@@ -89,7 +89,6 @@ pub struct GlWindowDevice {
     read_fbo: GLuint,
     events: EventBuffer,
     clip_planes: ClipPlanes,
-    is_running: bool,
 }
 
 impl Device for GlWindowDevice {
@@ -104,7 +103,7 @@ impl Device for GlWindowDevice {
         Views::Stereo(left, right)
     }
 
-    fn wait_for_animation_frame(&mut self) -> Frame {
+    fn wait_for_animation_frame(&mut self) -> Option<Frame> {
         self.window.swap_buffers();
         let translation = Vector3D::new(0.0, 0.0, -5.0);
         let transform = RigidTransform3D::from_translation(translation);
@@ -113,11 +112,11 @@ impl Device for GlWindowDevice {
         } else {
             vec![]
         };
-        Frame {
+        Some(Frame {
             transform,
             inputs: vec![],
             events,
-        }
+        })
     }
 
     fn render_animation_frame(
@@ -178,12 +177,7 @@ impl Device for GlWindowDevice {
         self.events.upgrade(dest)
     }
 
-    fn is_running(&self) -> bool {
-        self.is_running
-    }
-
     fn quit(&mut self) {
-        self.is_running = false;
         self.events.callback(Event::SessionEnd);
     }
 
@@ -210,7 +204,6 @@ impl GlWindowDevice {
             read_fbo,
             events: Default::default(),
             clip_planes: Default::default(),
-            is_running: true,
         })
     }
 

--- a/webxr/googlevr/device.rs
+++ b/webxr/googlevr/device.rs
@@ -63,7 +63,6 @@ pub(crate) struct GoogleVRDevice {
     depth: bool,
     clip_planes: ClipPlanes,
     input: Option<GoogleVRController>,
-    is_running: bool,
 
     #[cfg(target_os = "android")]
     java_class: ndk::jclass,
@@ -99,7 +98,6 @@ impl GoogleVRDevice {
             depth: false,
             clip_planes: Default::default(),
             input: None,
-            is_running: true,
 
             ctx: ctx.get(),
             controller_ctx: controller_ctx.get(),
@@ -141,7 +139,6 @@ impl GoogleVRDevice {
             depth: false,
             clip_planes: Default::default(),
             input: None,
-            is_running: true,
 
             ctx: ctx.get(),
             controller_ctx: controller_ctx.get(),
@@ -532,7 +529,7 @@ impl Device for GoogleVRDevice {
         }
     }
 
-    fn wait_for_animation_frame(&mut self) -> Frame {
+    fn wait_for_animation_frame(&mut self) -> Option<Frame> {
         unsafe {
             self.acquire_frame();
         }
@@ -542,11 +539,11 @@ impl Device for GoogleVRDevice {
             vec![]
         };
         // Predict head matrix
-        Frame {
+        Some(Frame {
             transform: self.fetch_head_matrix(),
             inputs: self.input_state(),
             events,
-        }
+        })
     }
 
     fn render_animation_frame(
@@ -582,14 +579,9 @@ impl Device for GoogleVRDevice {
         self.events.upgrade(dest);
     }
 
-    fn is_running(&self) -> bool {
-        self.is_running
-    }
-
     fn quit(&mut self) {
         self.stop_present();
         self.events.callback(Event::SessionEnd);
-        self.is_running = false;
     }
 
     fn set_quitter(&mut self, _: Quitter) {

--- a/webxr/magicleap/mod.rs
+++ b/webxr/magicleap/mod.rs
@@ -98,7 +98,6 @@ pub struct MagicLeapDevice {
     frame_handle: MLHandle,
     cameras: MLGraphicsVirtualCameraInfoArray,
     view_update_needed: bool,
-    is_running: bool,
 }
 
 impl MagicLeapDiscovery {
@@ -165,7 +164,6 @@ impl MagicLeapDevice {
             frame_handle,
             cameras,
             view_update_needed: false,
-            is_running: true,
         };
 
         // Rather annoyingly, in order for the views to be available, we have to
@@ -444,12 +442,7 @@ impl Device for MagicLeapDevice {
         // TODO: handle events
     }
 
-    fn is_running(&self) -> bool {
-        self.is_running
-    }
-
     fn quit(&mut self) {
-        self.is_running = false;
         // TODO: handle quit
     }
 


### PR DESCRIPTION
This fixes 2 different crashes at shutdown.

The initial approach of checking if session was running, then call RAF would fail as we would call `is_running()` before processing the event.

I got rid of the `is_running()` mechanic and instead made `wait_for_animation_frame` return an Option. Assuming that returning None mean the session has ended.

Fix #47