### PR TITLE
Remove STOPPING state handling

### DIFF
--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -331,11 +331,6 @@ impl OpenXrDevice {
             let event = self.instance.poll_event(&mut buffer).unwrap();
             match event {
                 Some(SessionStateChanged(session_change)) => match session_change.state() {
-                    openxr::SessionState::STOPPING => {
-                        self.events.callback(Event::SessionEnd);
-                        self.session.end().unwrap();
-                        return false;
-                    }
                     openxr::SessionState::EXITING | openxr::SessionState::LOSS_PENDING => {
                         break;
                     }


### PR DESCRIPTION
STOPPING is the transition into the IDLE state, not an exit event


Ideally we should be using this for triggering visibility blurred events, but I'm never seeing the IDLE or VISIBLE states.

I suspect this has something to do with wait_for_animation_frame, HL may be pausing w_a_f when it goes into IDLE, and throwing away the events we don't immediately ask for.

I suspect those events are going into EventsLost, whch we don't yet check.


r? @jdm