### PR TITLE
openxr: Submit correct pose values for reprojection

### DIFF
--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -618,8 +618,8 @@ impl Device for OpenXrDevice {
                                     }),
                             ),
                         openxr::CompositionLayerProjectionView::new()
-                            .pose(self.openxr_views[0].pose)
-                            .fov(self.openxr_views[0].fov)
+                            .pose(self.openxr_views[1].pose)
+                            .fov(self.openxr_views[1].fov)
                             .sub_image(
                                 openxr::SwapchainSubImage::new()
                                     .swapchain(&self.right_swapchain)


### PR DESCRIPTION
We were submitting the wrong pose values for the right eye, leading to the reprojection being distorted and causing #80

Fixes #80