### PR TITLE
Move surfman out of webxr-api

### DIFF
--- a/webxr-api/Cargo.toml
+++ b/webxr-api/Cargo.toml
@@ -23,8 +23,6 @@ ipc = ["serde", "ipc-channel", "euclid/serde"]
 
 [dependencies]
 euclid = "0.20"
-surfman = { version = "0.1", features = ["sm-osmesa"] }
-surfman-chains = "0.1"
 ipc-channel = { version = "0.12", optional = true }
 log = "0.4"
 serde = { version = "1.0", optional = true }

--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -82,6 +82,22 @@ impl SwapChainId {
 
 static NEXT_SWAP_CHAIN_ID: AtomicUsize = AtomicUsize::new(0);
 
+pub trait SwapChain {
+    type Surface: Surface;
+
+    fn take_surface(&self) -> Option<Self::Surface>;
+    fn recycle_surface(&self, surface: Self::Surface);
+}
+
+pub trait SwapChains: Clone + Send {
+    type SwapChain: SwapChain<Surface = Self::Surface>;
+    type Surface: Surface;
+
+    fn get(&self, id: SwapChainId) -> Option<Self::SwapChain>;
+}
+
+pub trait Surface {}
+
 #[cfg(feature = "ipc")]
 use std::thread;
 

--- a/webxr-api/mock.rs
+++ b/webxr-api/mock.rs
@@ -12,6 +12,7 @@ use crate::InputSource;
 use crate::Native;
 use crate::Receiver;
 use crate::Sender;
+use crate::SwapChains;
 use crate::TargetRayMode;
 use crate::Viewer;
 use crate::Views;
@@ -23,11 +24,12 @@ use serde::{Deserialize, Serialize};
 
 /// A trait for discovering mock XR devices
 pub trait MockDiscovery: 'static {
+    type SwapChains: SwapChains;
     fn simulate_device_connection(
         &mut self,
         init: MockDeviceInit,
         receiver: Receiver<MockDeviceMsg>,
-    ) -> Result<Box<dyn Discovery>, Error>;
+    ) -> Result<Box<dyn Discovery<SwapChains = Self::SwapChains>>, Error>;
 }
 
 #[derive(Clone, Debug)]

--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -41,6 +41,7 @@ gvr-sys = { version = "0.7", optional = true }
 openxr = { version = "0.9.1", optional = true }
 serde = { version = "1.0", optional = true }
 surfman = { version="0.1", features = ["sm-osmesa"] }
+surfman-chains = { version = "0.1" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["dxgi", "d3d11", "winerror"], optional = true }

--- a/webxr/googlevr/discovery.rs
+++ b/webxr/googlevr/discovery.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::SwapChains;
 use webxr_api::Discovery;
 use webxr_api::Error;
 use webxr_api::Session;
@@ -66,8 +67,14 @@ impl GoogleVRDiscovery {
 }
 
 impl Discovery for GoogleVRDiscovery {
+    type SwapChains = SwapChains;
+
     #[cfg(target_os = "android")]
-    fn request_session(&mut self, mode: SessionMode, xr: SessionBuilder) -> Result<Session, Error> {
+    fn request_session(
+        &mut self,
+        mode: SessionMode,
+        xr: SessionBuilder<SwapChains>,
+    ) -> Result<Session, Error> {
         let (ctx, controller_ctx, java_class, java_object);
         unsafe {
             ctx = SendPtr::new(self.ctx);
@@ -83,7 +90,11 @@ impl Discovery for GoogleVRDiscovery {
     }
 
     #[cfg(not(target_os = "android"))]
-    fn request_session(&mut self, mode: SessionMode, xr: SessionBuilder) -> Result<Session, Error> {
+    fn request_session(
+        &mut self,
+        mode: SessionMode,
+        xr: SessionBuilder<SwapChains>,
+    ) -> Result<Session, Error> {
         let (ctx, controller_ctx);
         unsafe {
             ctx = SendPtr::new(self.ctx);

--- a/webxr/lib.rs
+++ b/webxr/lib.rs
@@ -29,3 +29,39 @@ mod egl;
 pub mod openxr;
 
 pub(crate) mod utils;
+
+pub struct Surface(pub surfman::platform::generic::universal::surface::Surface);
+
+impl webxr_api::Surface for Surface {}
+
+impl std::ops::Deref for Surface {
+    type Target = surfman::platform::generic::universal::surface::Surface;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct SwapChain(surfman_chains::SwapChain);
+
+impl webxr_api::SwapChain for SwapChain {
+    type Surface = Surface;
+
+    fn take_surface(&self) -> Option<Self::Surface> {
+        self.0.take_surface().map(Surface)
+    }
+    fn recycle_surface(&self, surface: Self::Surface) {
+        self.0.recycle_surface(surface.0)
+    }
+}
+
+#[derive(Clone)]
+pub struct SwapChains(pub surfman_chains::SwapChains<webxr_api::SwapChainId>);
+
+impl webxr_api::SwapChains for SwapChains {
+    type SwapChain = SwapChain;
+    type Surface = Surface;
+
+    fn get(&self, id: webxr_api::SwapChainId) -> Option<Self::SwapChain> {
+        self.0.get(id).map(SwapChain)
+    }
+}


### PR DESCRIPTION
Having surfman in the public api of webxr-api means that we rebuild some of the largest parts of Servo when changing surfman. These changes use generics to remove that dependency. It's not a perfect end result; it would be conceptually cleaner to push the Surface/SwapChains/SwapChain implementations into Servo itself, but that quickly runs into more complicated type shenanigans without actually yielding a significantly better compilation path.