### PR TITLE
Remove dependency from webxr-api to surfman

### DIFF
--- a/webxr-api/Cargo.toml
+++ b/webxr-api/Cargo.toml
@@ -23,8 +23,7 @@ ipc = ["serde", "ipc-channel", "euclid/serde"]
 
 [dependencies]
 euclid = "0.20"
-surfman = { version = "0.1", features = ["sm-osmesa"] }
-surfman-chains = "0.1"
+surfman-chains-api = "0.2"
 ipc-channel = { version = "0.12", optional = true }
 log = "0.4"
 serde = { version = "1.0", optional = true }

--- a/webxr-api/device.rs
+++ b/webxr-api/device.rs
@@ -22,16 +22,18 @@ use crate::Views;
 use euclid::RigidTransform3D;
 use euclid::Size2D;
 
-use surfman::platform::generic::universal::surface::Surface;
-
 /// A trait for discovering XR devices
-pub trait Discovery: 'static {
-    fn request_session(&mut self, mode: SessionMode, xr: SessionBuilder) -> Result<Session, Error>;
+pub trait DiscoveryAPI<SwapChains>: 'static {
+    fn request_session(
+        &mut self,
+        mode: SessionMode,
+        xr: SessionBuilder<SwapChains>,
+    ) -> Result<Session, Error>;
     fn supports_session(&self, mode: SessionMode) -> bool;
 }
 
 /// A trait for using an XR device
-pub trait Device: 'static {
+pub trait DeviceAPI<Surface>: 'static {
     /// The transform from native coordinates to the floor.
     fn floor_transform(&self) -> RigidTransform3D<f32, Native, Floor>;
 
@@ -77,8 +79,12 @@ pub trait Device: 'static {
     }
 }
 
-impl Discovery for Box<dyn Discovery> {
-    fn request_session(&mut self, mode: SessionMode, xr: SessionBuilder) -> Result<Session, Error> {
+impl<SwapChains: 'static> DiscoveryAPI<SwapChains> for Box<dyn DiscoveryAPI<SwapChains>> {
+    fn request_session(
+        &mut self,
+        mode: SessionMode,
+        xr: SessionBuilder<SwapChains>,
+    ) -> Result<Session, Error> {
         (&mut **self).request_session(mode, xr)
     }
 

--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -20,8 +20,8 @@ mod registry;
 mod session;
 mod view;
 
-pub use device::Device;
-pub use device::Discovery;
+pub use device::DeviceAPI;
+pub use device::DiscoveryAPI;
 
 pub use error::Error;
 
@@ -41,7 +41,7 @@ pub use input::TargetRayMode;
 
 pub use mock::MockDeviceInit;
 pub use mock::MockDeviceMsg;
-pub use mock::MockDiscovery;
+pub use mock::MockDiscoveryAPI;
 pub use mock::MockInputInit;
 pub use mock::MockInputMsg;
 

--- a/webxr-api/mock.rs
+++ b/webxr-api/mock.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::Discovery;
+use crate::DiscoveryAPI;
 use crate::Error;
 use crate::Floor;
 use crate::Handedness;
@@ -22,12 +22,12 @@ use euclid::RigidTransform3D;
 use serde::{Deserialize, Serialize};
 
 /// A trait for discovering mock XR devices
-pub trait MockDiscovery: 'static {
+pub trait MockDiscoveryAPI<SwapChains>: 'static {
     fn simulate_device_connection(
         &mut self,
         init: MockDeviceInit,
         receiver: Receiver<MockDeviceMsg>,
-    ) -> Result<Box<dyn Discovery>, Error>;
+    ) -> Result<Box<dyn DiscoveryAPI<SwapChains>>, Error>;
 }
 
 #[derive(Clone, Debug)]

--- a/webxr-api/session.rs
+++ b/webxr-api/session.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::Device;
+use crate::DeviceAPI;
 use crate::Error;
 use crate::Event;
 use crate::Floor;
@@ -22,8 +22,8 @@ use euclid::Size2D;
 use std::thread;
 use std::time::Duration;
 
-use surfman_chains::SwapChain;
-use surfman_chains::SwapChains;
+use surfman_chains_api::SwapChainAPI;
+use surfman_chains_api::SwapChainsAPI;
 
 #[cfg(feature = "ipc")]
 use serde::{Deserialize, Serialize};
@@ -141,21 +141,22 @@ impl Session {
 }
 
 /// For devices that want to do their own thread management, the `SessionThread` type is exposed.
-pub struct SessionThread<D> {
+pub struct SessionThread<Device, SwapChains: SwapChainsAPI<SwapChainId>> {
     receiver: Receiver<SessionMsg>,
     sender: Sender<SessionMsg>,
-    swap_chain: Option<SwapChain>,
-    swap_chains: SwapChains<SwapChainId>,
+    swap_chain: Option<SwapChains::SwapChain>,
+    swap_chains: SwapChains,
     timestamp: HighResTimeStamp,
     running: bool,
-    device: D,
+    device: Device,
 }
 
-impl<D: Device> SessionThread<D> {
-    pub fn new(
-        mut device: D,
-        swap_chains: SwapChains<SwapChainId>,
-    ) -> Result<SessionThread<D>, Error> {
+impl<Device, SwapChains> SessionThread<Device, SwapChains>
+where
+    Device: DeviceAPI<SwapChains::Surface>,
+    SwapChains: SwapChainsAPI<SwapChainId>,
+{
+    pub fn new(mut device: Device, swap_chains: SwapChains) -> Result<Self, Error> {
         let (sender, receiver) = crate::channel().or(Err(Error::CommunicationError))?;
         device.set_quitter(Quitter {
             sender: sender.clone(),
@@ -247,7 +248,11 @@ pub trait MainThreadSession: 'static {
     fn running(&self) -> bool;
 }
 
-impl<D: Device> MainThreadSession for SessionThread<D> {
+impl<Device, SwapChains> MainThreadSession for SessionThread<Device, SwapChains>
+where
+    Device: DeviceAPI<SwapChains::Surface>,
+    SwapChains: SwapChainsAPI<SwapChainId>,
+{
     fn run_one_frame(&mut self) {
         let timestamp = self.timestamp;
         while timestamp == self.timestamp && self.running {
@@ -265,16 +270,19 @@ impl<D: Device> MainThreadSession for SessionThread<D> {
 }
 
 /// A type for building XR sessions
-pub struct SessionBuilder<'a> {
-    swap_chains: &'a SwapChains<SwapChainId>,
+pub struct SessionBuilder<'a, SwapChains: 'a> {
+    swap_chains: &'a SwapChains,
     sessions: &'a mut Vec<Box<dyn MainThreadSession>>,
 }
 
-impl<'a> SessionBuilder<'a> {
+impl<'a, SwapChains> SessionBuilder<'a, SwapChains>
+where
+    SwapChains: SwapChainsAPI<SwapChainId>,
+{
     pub(crate) fn new(
-        swap_chains: &'a SwapChains<SwapChainId>,
+        swap_chains: &'a SwapChains,
         sessions: &'a mut Vec<Box<dyn MainThreadSession>>,
-    ) -> SessionBuilder<'a> {
+    ) -> Self {
         SessionBuilder {
             swap_chains,
             sessions,
@@ -282,10 +290,10 @@ impl<'a> SessionBuilder<'a> {
     }
 
     /// For devices which are happy to hand over thread management to webxr.
-    pub fn spawn<D, F>(self, factory: F) -> Result<Session, Error>
+    pub fn spawn<Device, Factory>(self, factory: Factory) -> Result<Session, Error>
     where
-        F: 'static + FnOnce() -> Result<D, Error> + Send,
-        D: Device,
+        Factory: 'static + FnOnce() -> Result<Device, Error> + Send,
+        Device: DeviceAPI<SwapChains::Surface>,
     {
         let (acks, ackr) = crate::channel().or(Err(Error::CommunicationError))?;
         let swap_chains = self.swap_chains.clone();
@@ -305,10 +313,10 @@ impl<'a> SessionBuilder<'a> {
     }
 
     /// For devices that need to run on the main thread.
-    pub fn run_on_main_thread<D, F>(self, factory: F) -> Result<Session, Error>
+    pub fn run_on_main_thread<Device, Factory>(self, factory: Factory) -> Result<Session, Error>
     where
-        F: 'static + FnOnce() -> Result<D, Error>,
-        D: Device,
+        Factory: 'static + FnOnce() -> Result<Device, Error>,
+        Device: DeviceAPI<SwapChains::Surface>,
     {
         let device = factory()?;
         let swap_chains = self.swap_chains.clone();

--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -40,7 +40,8 @@ log = "0.4.6"
 gvr-sys = { version = "0.7", optional = true }
 openxr = { version = "0.9.1", optional = true }
 serde = { version = "1.0", optional = true }
-surfman = { version="0.1", features = ["sm-osmesa"] }
+surfman = { version = "0.1", features = ["sm-osmesa"] }
+surfman-chains = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["dxgi", "d3d11", "winerror"], optional = true }

--- a/webxr/glwindow/mod.rs
+++ b/webxr/glwindow/mod.rs
@@ -3,6 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::utils::ClipPlanes;
+use crate::SessionBuilder;
+use crate::SwapChains;
+
 use euclid::default::Size2D as UntypedSize2D;
 use euclid::Angle;
 use euclid::Point2D;
@@ -29,8 +32,8 @@ use surfman::platform::generic::universal::context::Context;
 use surfman::platform::generic::universal::device::Device as SurfmanDevice;
 use surfman::platform::generic::universal::surface::Surface;
 
-use webxr_api::Device;
-use webxr_api::Discovery;
+use webxr_api::DeviceAPI;
+use webxr_api::DiscoveryAPI;
 use webxr_api::Display;
 use webxr_api::Error;
 use webxr_api::Event;
@@ -43,7 +46,6 @@ use webxr_api::Native;
 use webxr_api::Quitter;
 use webxr_api::Sender;
 use webxr_api::Session;
-use webxr_api::SessionBuilder;
 use webxr_api::SessionMode;
 use webxr_api::View;
 use webxr_api::Views;
@@ -73,7 +75,7 @@ impl GlWindowDiscovery {
     }
 }
 
-impl Discovery for GlWindowDiscovery {
+impl DiscoveryAPI<SwapChains> for GlWindowDiscovery {
     fn request_session(&mut self, mode: SessionMode, xr: SessionBuilder) -> Result<Session, Error> {
         if self.supports_session(mode) {
             let gl = self.gl.clone();
@@ -99,7 +101,7 @@ pub struct GlWindowDevice {
     clip_planes: ClipPlanes,
 }
 
-impl Device for GlWindowDevice {
+impl DeviceAPI<Surface> for GlWindowDevice {
     fn floor_transform(&self) -> RigidTransform3D<f32, Native, Floor> {
         let translation = Vector3D::new(-HEIGHT, 0.0, 0.0);
         RigidTransform3D::from_translation(translation)

--- a/webxr/googlevr/device.rs
+++ b/webxr/googlevr/device.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use webxr_api::Device;
+use webxr_api::DeviceAPI;
 use webxr_api::Error;
 use webxr_api::Event;
 use webxr_api::EventBuffer;
@@ -528,7 +528,7 @@ impl GoogleVRDevice {
     }
 }
 
-impl Device for GoogleVRDevice {
+impl DeviceAPI<Surface> for GoogleVRDevice {
     fn floor_transform(&self) -> RigidTransform3D<f32, Native, Floor> {
         // GoogleVR doesn't know about the floor
         // XXXManishearth perhaps we should report a guesstimate value here

--- a/webxr/googlevr/discovery.rs
+++ b/webxr/googlevr/discovery.rs
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use webxr_api::Discovery;
+use crate::SessionBuilder;
+use crate::SwapChains;
+
+use webxr_api::DiscoveryAPI;
 use webxr_api::Error;
 use webxr_api::Session;
-use webxr_api::SessionBuilder;
 use webxr_api::SessionMode;
 
 use log::warn;
@@ -65,7 +67,7 @@ impl GoogleVRDiscovery {
     }
 }
 
-impl Discovery for GoogleVRDiscovery {
+impl DiscoveryAPI<SwapChains> for GoogleVRDiscovery {
     #[cfg(target_os = "android")]
     fn request_session(&mut self, mode: SessionMode, xr: SessionBuilder) -> Result<Session, Error> {
         let (ctx, controller_ctx, java_class, java_object);

--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use webxr_api::Device;
-use webxr_api::Discovery;
+use crate::SessionBuilder;
+use crate::SwapChains;
+
+use webxr_api::DeviceAPI;
+use webxr_api::DiscoveryAPI;
 use webxr_api::Error;
 use webxr_api::Event;
 use webxr_api::EventBuffer;
@@ -15,14 +18,13 @@ use webxr_api::InputFrame;
 use webxr_api::InputSource;
 use webxr_api::MockDeviceInit;
 use webxr_api::MockDeviceMsg;
-use webxr_api::MockDiscovery;
+use webxr_api::MockDiscoveryAPI;
 use webxr_api::MockInputMsg;
 use webxr_api::Native;
 use webxr_api::Quitter;
 use webxr_api::Receiver;
 use webxr_api::Sender;
 use webxr_api::Session;
-use webxr_api::SessionBuilder;
 use webxr_api::SessionMode;
 use webxr_api::Viewer;
 use webxr_api::Views;
@@ -62,12 +64,12 @@ struct HeadlessDeviceData {
     disconnected: bool,
 }
 
-impl MockDiscovery for HeadlessMockDiscovery {
+impl MockDiscoveryAPI<SwapChains> for HeadlessMockDiscovery {
     fn simulate_device_connection(
         &mut self,
         init: MockDeviceInit,
         receiver: Receiver<MockDeviceMsg>,
-    ) -> Result<Box<dyn Discovery>, Error> {
+    ) -> Result<Box<dyn DiscoveryAPI<SwapChains>>, Error> {
         let viewer_origin = init.viewer_origin.clone();
         let floor_transform = init.floor_origin.inverse();
         let views = init.views.clone();
@@ -102,7 +104,7 @@ fn run_loop(receiver: Receiver<MockDeviceMsg>, data: Arc<Mutex<HeadlessDeviceDat
     }
 }
 
-impl Discovery for HeadlessDiscovery {
+impl DiscoveryAPI<SwapChains> for HeadlessDiscovery {
     fn request_session(&mut self, mode: SessionMode, xr: SessionBuilder) -> Result<Session, Error> {
         if self.data.lock().unwrap().disconnected || !self.supports_session(mode) {
             return Err(Error::NoMatchingDevice);
@@ -116,7 +118,7 @@ impl Discovery for HeadlessDiscovery {
     }
 }
 
-impl Device for HeadlessDevice {
+impl DeviceAPI<Surface> for HeadlessDevice {
     fn floor_transform(&self) -> RigidTransform3D<f32, Native, Floor> {
         self.data.lock().unwrap().floor_transform.clone()
     }

--- a/webxr/lib.rs
+++ b/webxr/lib.rs
@@ -29,3 +29,15 @@ mod egl;
 pub mod openxr;
 
 pub(crate) mod utils;
+
+/// A type synonym for swap chains
+pub type SwapChains = surfman_chains::SwapChains<webxr_api::SwapChainId>;
+
+/// A type synonym for the main thread registry
+pub type MainThreadRegistry = webxr_api::MainThreadRegistry<SwapChains>;
+
+/// A type synonym for the session builder
+pub type SessionBuilder<'a> = webxr_api::SessionBuilder<'a, SwapChains>;
+
+/// A type synonym for discovery objects
+pub type Discovery = Box<dyn webxr_api::DiscoveryAPI<SwapChains>>;

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -1,4 +1,7 @@
 use crate::utils::ClipPlanes;
+use crate::SessionBuilder;
+use crate::SwapChains;
+
 use euclid::Point2D;
 use euclid::Rect;
 use euclid::RigidTransform3D;
@@ -22,8 +25,8 @@ use surfman::platform::generic::universal::context::Context as SurfmanContext;
 use surfman::platform::generic::universal::device::Device as SurfmanDevice;
 use surfman::platform::generic::universal::surface::Surface;
 use webxr_api;
-use webxr_api::Device;
-use webxr_api::Discovery;
+use webxr_api::DeviceAPI;
+use webxr_api::DiscoveryAPI;
 use webxr_api::Error;
 use webxr_api::Event;
 use webxr_api::EventBuffer;
@@ -37,7 +40,6 @@ use webxr_api::Native;
 use webxr_api::Quitter;
 use webxr_api::Sender;
 use webxr_api::Session as WebXrSession;
-use webxr_api::SessionBuilder;
 use webxr_api::SessionMode;
 use webxr_api::TargetRayMode;
 use webxr_api::View;
@@ -96,7 +98,7 @@ fn pick_format(formats: &[dxgiformat::DXGI_FORMAT]) -> dxgiformat::DXGI_FORMAT {
     panic!("No formats supported amongst {:?}", formats);
 }
 
-impl Discovery for OpenXrDiscovery {
+impl DiscoveryAPI<SwapChains> for OpenXrDiscovery {
     fn request_session(
         &mut self,
         mode: SessionMode,
@@ -354,7 +356,7 @@ impl OpenXrDevice {
     }
 }
 
-impl Device for OpenXrDevice {
+impl DeviceAPI<Surface> for OpenXrDevice {
     fn floor_transform(&self) -> RigidTransform3D<f32, Native, Floor> {
         let translation = Vector3D::new(-HEIGHT, 0.0, 0.0);
         RigidTransform3D::from_translation(translation)


### PR DESCRIPTION
Means that changes to surfman don't cause rebuilds of anything that depends on webxr-api.