### PR TITLE
Prepare API for squeeze events

### DIFF
--- a/webxr-api/events.rs
+++ b/webxr-api/events.rs
@@ -20,7 +20,7 @@ pub enum Event {
     /// Session focused/blurred/etc
     VisibilityChange(Visibility),
     /// Selection started / ended
-    Select(InputId, SelectEvent, Frame),
+    Select(InputId, /* is_squeeze */ bool, SelectEvent, Frame),
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/webxr-api/events.rs
+++ b/webxr-api/events.rs
@@ -6,6 +6,7 @@ use crate::Frame;
 use crate::InputId;
 use crate::InputSource;
 use crate::SelectEvent;
+use crate::SelectKind;
 use crate::Sender;
 
 #[derive(Clone, Debug)]
@@ -20,7 +21,7 @@ pub enum Event {
     /// Session focused/blurred/etc
     VisibilityChange(Visibility),
     /// Selection started / ended
-    Select(InputId, /* is_squeeze */ bool, SelectEvent, Frame),
+    Select(InputId, SelectKind, SelectEvent, Frame),
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/webxr-api/input.rs
+++ b/webxr-api/input.rs
@@ -56,3 +56,10 @@ pub enum SelectEvent {
     /// Selection ended *with* it being a contiguous select event
     Select,
 }
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+pub enum SelectKind {
+    Select,
+    Squeeze,
+}

--- a/webxr-api/input.rs
+++ b/webxr-api/input.rs
@@ -43,6 +43,7 @@ pub struct InputFrame {
     pub target_ray_origin: Option<RigidTransform3D<f32, Input, Native>>,
     pub grip_origin: Option<RigidTransform3D<f32, Input, Native>>,
     pub pressed: bool,
+    pub squeezed: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -37,6 +37,7 @@ pub use input::InputFrame;
 pub use input::InputId;
 pub use input::InputSource;
 pub use input::SelectEvent;
+pub use input::SelectKind;
 pub use input::TargetRayMode;
 
 pub use mock::MockDeviceInit;

--- a/webxr/googlevr/device.rs
+++ b/webxr/googlevr/device.rs
@@ -521,6 +521,7 @@ impl GoogleVRDevice {
                 id: InputId(0),
                 grip_origin: None,
                 pressed: false,
+                squeezed: false,
             }]
         } else {
             vec![]

--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -139,6 +139,7 @@ impl DeviceAPI<Surface> for HeadlessDevice {
                 target_ray_origin: Some(i.pointer),
                 grip_origin: None,
                 pressed: false,
+                squeezed: false,
             })
             .collect();
 

--- a/webxr/openxr/input.rs
+++ b/webxr/openxr/input.rs
@@ -20,6 +20,40 @@ enum ClickState {
     Done,
 }
 
+impl ClickState {
+    fn update(
+        &mut self,
+        action: &Action<bool>,
+        session: &Session<D3D11>,
+    ) -> (/* is_active */ bool, Option<SelectEvent>) {
+        let click = action.state(session, Path::NULL).unwrap();
+
+        let select_event = if click.is_active {
+            match (click.current_state, *self) {
+                (true, ClickState::Done) => {
+                    *self = ClickState::Clicking;
+                    Some(SelectEvent::Start)
+                }
+                (false, ClickState::Clicking) => {
+                    *self = ClickState::Done;
+                    Some(SelectEvent::Select)
+                }
+                (false, ClickState::ClickingLost) => {
+                    *self = ClickState::Done;
+                    Some(SelectEvent::End)
+                }
+                _ => None,
+            }
+        } else if *self == ClickState::Clicking {
+            *self = ClickState::ClickingLost;
+            None
+        } else {
+            None
+        };
+        (click.is_active, select_event)
+    }
+}
+
 const IDENTITY_POSE: Posef = Posef {
     orientation: Quaternionf {
         x: 0.,
@@ -124,33 +158,12 @@ impl OpenXRInput {
 
         let click = self.action_click.state(session, Path::NULL).unwrap();
 
-        let select_event = if click.is_active {
-            match (click.current_state, self.click_state) {
-                (true, ClickState::Done) => {
-                    self.click_state = ClickState::Clicking;
-                    Some(SelectEvent::Start)
-                }
-                (false, ClickState::Clicking) => {
-                    self.click_state = ClickState::Done;
-                    Some(SelectEvent::Select)
-                }
-                (false, ClickState::ClickingLost) => {
-                    self.click_state = ClickState::Done;
-                    Some(SelectEvent::End)
-                }
-                _ => None,
-            }
-        } else if self.click_state == ClickState::Clicking {
-            self.click_state = ClickState::ClickingLost;
-            None
-        } else {
-            None
-        };
+        let (is_active, select_event) = self.click_state.update(&self.action_click, session);
 
         let input_frame = InputFrame {
             target_ray_origin,
             id: self.id,
-            pressed: click.is_active && click.current_state,
+            pressed: is_active && click.current_state,
             grip_origin,
         };
 

--- a/webxr/openxr/input.rs
+++ b/webxr/openxr/input.rs
@@ -164,6 +164,7 @@ impl OpenXRInput {
             target_ray_origin,
             id: self.id,
             pressed: is_active && click.current_state,
+            squeezed: false,
             grip_origin,
         };
 

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -38,6 +38,7 @@ use webxr_api::InputId;
 use webxr_api::InputSource;
 use webxr_api::Native;
 use webxr_api::Quitter;
+use webxr_api::SelectKind;
 use webxr_api::Sender;
 use webxr_api::Session as WebXrSession;
 use webxr_api::SessionMode;
@@ -451,14 +452,18 @@ impl DeviceAPI<Surface> for OpenXrDevice {
         if let Some(right_select) = right_select {
             self.events.callback(Event::Select(
                 InputId(0),
-                false,
+                SelectKind::Select,
                 right_select,
                 frame.clone(),
             ));
         }
         if let Some(left_select) = left_select {
-            self.events
-                .callback(Event::Select(InputId(1), false, left_select, frame.clone()));
+            self.events.callback(Event::Select(
+                InputId(1),
+                SelectKind::Select,
+                left_select,
+                frame.clone(),
+            ));
         }
 
         // todo use pose in input

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -449,12 +449,16 @@ impl DeviceAPI<Surface> for OpenXrDevice {
         };
 
         if let Some(right_select) = right_select {
-            self.events
-                .callback(Event::Select(InputId(0), right_select, frame.clone()));
+            self.events.callback(Event::Select(
+                InputId(0),
+                false,
+                right_select,
+                frame.clone(),
+            ));
         }
         if let Some(left_select) = left_select {
             self.events
-                .callback(Event::Select(InputId(1), left_select, frame.clone()));
+                .callback(Event::Select(InputId(1), false, left_select, frame.clone()));
         }
 
         // todo use pose in input


### PR DESCRIPTION
We can't yet support squeeze events on hololens, but the code here will make it super easy to add support when we need to.

r? @jdm

This is a breaking change and needs to be landed simultaneously with https://github.com/servo/servo/pull/24838