### PR TITLE
Run headless device on its own thread.

### DIFF
--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -132,7 +132,7 @@ impl DiscoveryAPI<SwapChains> for HeadlessDiscovery {
         let data = self.data.clone();
         let clip_planes = Default::default();
         let granted_features = init.validate(mode, &data.lock().unwrap().supported_features)?;
-        xr.run_on_main_thread(move || {
+        xr.spawn(move || {
             Ok(HeadlessDevice {
                 data,
                 mode,


### PR DESCRIPTION
We really want to stop using the main thread code path as much as possible, and it avoids timeouts in https://github.com/servo/servo/pull/25837/ when the main thread blocks in other parts of the pipeline and never ends up processing the pending XR events.