### PR TITLE
Disable nightly while rustfmt is missing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-  - nightly
+  #- nightly
   - stable
 
 before_script:


### PR DESCRIPTION
rustfmt has been missing from nightlies for three days (https://rust-lang.github.io/rustup-components-history/) and this is preventing us from merging anything in repositories that require it.