### PR TITLE
Improve context menu gesture to incorporate gaze, correctly trigger selectcancel events when the context menu is shown

### DIFF
--- a/webxr/openxr/input.rs
+++ b/webxr/openxr/input.rs
@@ -10,6 +10,7 @@ use webxr_api::InputFrame;
 use webxr_api::InputId;
 use webxr_api::Native;
 use webxr_api::SelectEvent;
+use webxr_api::Viewer;
 
 /// Number of frames to wait with the menu gesture before
 /// opening the menu.
@@ -230,6 +231,7 @@ impl OpenXRInput {
         session: &Session<D3D11>,
         frame_state: &FrameState,
         base_space: &Space,
+        viewer: &RigidTransform3D<f32, Viewer, Native>,
     ) -> Frame {
         use euclid::Vector3D;
         let target_ray_origin = pose_for(&self.action_aim_space, frame_state, base_space);
@@ -242,28 +244,34 @@ impl OpenXRInput {
             // The X axis of the grip is perpendicular to the palm, however its
             // direction is the opposite for each hand
             //
-            // We obtain a unit vector poking out of the palm
+            // We obtain a unit vector pointing out of the palm
             let x_dir = if let Handedness::Left = self.handedness {
                 1.0
             } else {
                 -1.0
             };
-
             // Rotate it by the grip to obtain the desired vector
             let grip_x = grip_origin
                 .rotation
                 .transform_vector3d(Vector3D::new(x_dir, 0.0, 0.0));
-
-            // Dot product it with the "up" vector to see if it's pointing up
-            let angle = grip_x.dot(Vector3D::new(0.0, 1.0, 0.0));
+            let gaze = viewer
+                .rotation
+                .transform_vector3d(Vector3D::new(0., 0., 1.));
 
             // If the angle is close enough to 0, its cosine will be
             // close to 1
-            if angle > 0.9 {
-                self.menu_gesture_sustain += 1;
-                if self.menu_gesture_sustain > MENU_GESTURE_SUSTAIN_THRESHOLD {
-                    menu_selected = true;
-                    self.menu_gesture_sustain = 0;
+            // check if the user's gaze is parallel to the palm
+            if gaze.dot(grip_x) > 0.95 {
+                let input_relative = (viewer.translation - grip_origin.translation).normalize();
+                // if so, check if the user is actually looking at the palm
+                if gaze.dot(input_relative) > 0.95 {
+                    self.menu_gesture_sustain += 1;
+                    if self.menu_gesture_sustain > MENU_GESTURE_SUSTAIN_THRESHOLD {
+                        menu_selected = true;
+                        self.menu_gesture_sustain = 0;
+                    }
+                } else {
+                    self.menu_gesture_sustain = 0
                 }
             } else {
                 self.menu_gesture_sustain = 0;

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -762,10 +762,10 @@ impl DeviceAPI<Surface> for OpenXrDevice {
 
         if (left.menu_selected || right.menu_selected) && self.context_menu_future.is_none() {
             self.context_menu_future = Some(self.context_menu_provider.open_context_menu());
-        }
-
-        // Do not surface input info whilst the context menu is open
-        if self.context_menu_future.is_some() {
+        } else if self.context_menu_future.is_some() {
+            // Do not surface input info whilst the context menu is open
+            // We don't do this for the first frame after the context menu is opened
+            // so that the appropriate select cancel events may fire
             right.frame.target_ray_origin = None;
             right.frame.grip_origin = None;
             left.frame.target_ray_origin = None;

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -738,18 +738,18 @@ impl DeviceAPI<Surface> for OpenXrDevice {
             .viewer_space
             .locate(&data.space, data.frame_state.predicted_display_time)
             .unwrap();
-        let transform = Some(transform(&pose.pose));
+        let transform = transform(&pose.pose);
 
         let active_action_set = ActiveActionSet::new(&self.action_set);
 
         self.session.sync_actions(&[active_action_set]).unwrap();
 
-        let mut right = self
-            .right_hand
-            .frame(&self.session, &data.frame_state, &data.space);
-        let mut left = self
-            .left_hand
-            .frame(&self.session, &data.frame_state, &data.space);
+        let mut right =
+            self.right_hand
+                .frame(&self.session, &data.frame_state, &data.space, &transform);
+        let mut left =
+            self.left_hand
+                .frame(&self.session, &data.frame_state, &data.space, &transform);
 
         // views() needs to reacquire the lock.
         drop(data);
@@ -777,7 +777,7 @@ impl DeviceAPI<Surface> for OpenXrDevice {
         }
 
         let frame = Frame {
-            transform,
+            transform: Some(transform),
             inputs: vec![right.frame, left.frame],
             events,
             time_ns,


### PR DESCRIPTION
This changes the context menu gesture to be "looking straight at palm, with palm facing you" (easiest way to do this is hold the palm straight up in front of your face), which was suggested by Alex earlier. It also triggers the cancel events correctly so that when the context menu is exited the application doesn't think there was a continuous select event while the menu was shown.

This may make less sense for WinMR devices, but I can add a direct menu button press for those.
r? @jdm 