### PR TITLE
Implement support for hit testing, use in mock backend

### DIFF
--- a/webxr-api/device.rs
+++ b/webxr-api/device.rs
@@ -9,6 +9,8 @@ use crate::Error;
 use crate::Event;
 use crate::Floor;
 use crate::Frame;
+use crate::HitTestId;
+use crate::HitTestSource;
 use crate::InputSource;
 use crate::Native;
 use crate::Quitter;
@@ -82,6 +84,14 @@ pub trait DeviceAPI<Surface>: 'static {
     }
 
     fn granted_features(&self) -> &[String];
+
+    fn request_hit_test(&mut self, _source: HitTestSource) {
+        panic!("This device does not support requesting hit tests");
+    }
+
+    fn cancel_hit_test(&mut self, _id: HitTestId) {
+        panic!("This device does not support hit tests");
+    }
 }
 
 impl<SwapChains: 'static> DiscoveryAPI<SwapChains> for Box<dyn DiscoveryAPI<SwapChains>> {

--- a/webxr-api/frame.rs
+++ b/webxr-api/frame.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::Floor;
+use crate::HitTestId;
 use crate::InputFrame;
 use crate::Native;
 use crate::Viewer;
@@ -40,4 +41,5 @@ pub struct Frame {
 pub enum FrameUpdateEvent {
     UpdateViews(Views),
     UpdateFloorTransform(Option<RigidTransform3D<f32, Native, Floor>>),
+    HitTestSourceAdded(HitTestId),
 }

--- a/webxr-api/frame.rs
+++ b/webxr-api/frame.rs
@@ -4,6 +4,7 @@
 
 use crate::Floor;
 use crate::HitTestId;
+use crate::HitTestResult;
 use crate::InputFrame;
 use crate::Native;
 use crate::Viewer;
@@ -34,6 +35,9 @@ pub struct Frame {
 
     /// The time the frame was sent (only set with the profile feature)
     pub sent_time: u64,
+
+    /// The hit test results for this frame, if any
+    pub hit_test_results: Vec<HitTestResult>,
 }
 
 #[derive(Clone, Debug)]

--- a/webxr-api/hittest.rs
+++ b/webxr-api/hittest.rs
@@ -1,0 +1,73 @@
+use crate::ApiSpace;
+use crate::Space;
+use euclid::Vector3D;
+use std::iter::FromIterator;
+
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+/// https://immersive-web.github.io/hit-test/#xrray
+pub struct Ray {
+    pub origin: Vector3D<f32, ApiSpace>,
+    pub direction: Vector3D<f32, ApiSpace>,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+/// https://immersive-web.github.io/hit-test/#enumdef-xrhittesttrackabletype
+pub enum EntityType {
+    Point,
+    Plane,
+    Mesh,
+}
+
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+/// https://immersive-web.github.io/hit-test/#dictdef-xrhittestoptionsinit
+pub struct HitTestSource {
+    pub space: Space,
+    pub ray: Ray,
+    pub types: EntityTypes,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+pub struct HitTestId(pub u32);
+
+#[derive(Copy, Clone, Debug, Default)]
+#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+/// Vec<EntityType>, but better
+pub struct EntityTypes {
+    pub point: bool,
+    pub plane: bool,
+    pub mesh: bool,
+}
+
+impl EntityTypes {
+    pub fn is_type(self, ty: EntityType) -> bool {
+        match ty {
+            EntityType::Point => self.point,
+            EntityType::Plane => self.plane,
+            EntityType::Mesh => self.mesh,
+        }
+    }
+
+    pub fn add_type(&mut self, ty: EntityType) {
+        match ty {
+            EntityType::Point => self.point = true,
+            EntityType::Plane => self.plane = true,
+            EntityType::Mesh => self.mesh = true,
+        }
+    }
+}
+
+impl FromIterator<EntityType> for EntityTypes {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = EntityType>,
+    {
+        iter.into_iter().fold(Default::default(), |mut acc, e| {
+            acc.add_type(e);
+            acc
+        })
+    }
+}

--- a/webxr-api/hittest.rs
+++ b/webxr-api/hittest.rs
@@ -1,16 +1,21 @@
 use crate::ApiSpace;
 use crate::Native;
 use crate::Space;
+use euclid::Point3D;
 use euclid::RigidTransform3D;
+use euclid::Rotation3D;
 use euclid::Vector3D;
+use std::f32::EPSILON;
 use std::iter::FromIterator;
 
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
 /// https://immersive-web.github.io/hit-test/#xrray
-pub struct Ray {
-    pub origin: Vector3D<f32, ApiSpace>,
-    pub direction: Vector3D<f32, ApiSpace>,
+pub struct Ray<Space> {
+    /// The origin of the ray
+    pub origin: Vector3D<f32, Space>,
+    /// The direction of the ray. Must be normalized.
+    pub direction: Vector3D<f32, Space>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -28,7 +33,7 @@ pub enum EntityType {
 pub struct HitTestSource {
     pub id: HitTestId,
     pub space: Space,
-    pub ray: Ray,
+    pub ray: Ray<ApiSpace>,
     pub types: EntityTypes,
 }
 
@@ -57,6 +62,14 @@ pub struct HitTestResult {
 /// The coordinate space of a hit test result
 pub struct HitTestSpace;
 
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+pub struct Triangle {
+    pub first: Point3D<f32, Native>,
+    pub second: Point3D<f32, Native>,
+    pub third: Point3D<f32, Native>,
+}
+
 impl EntityTypes {
     pub fn is_type(self, ty: EntityType) -> bool {
         match ty {
@@ -84,5 +97,83 @@ impl FromIterator<EntityType> for EntityTypes {
             acc.add_type(e);
             acc
         })
+    }
+}
+
+impl Triangle {
+    /// https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm
+    pub fn intersect(
+        self,
+        ray: Ray<Native>,
+    ) -> Option<RigidTransform3D<f32, HitTestSpace, Native>> {
+        let Triangle {
+            first: v0,
+            second: v1,
+            third: v2,
+        } = self;
+
+        let edge1 = v1 - v0;
+        let edge2 = v2 - v0;
+
+        let h = ray.direction.cross(edge2);
+        let a = edge1.dot(h);
+        if a > -EPSILON && a < EPSILON {
+            // ray is parallel to triangle
+            return None;
+        }
+
+        let f = 1. / a;
+
+        let s = ray.origin - v0.to_vector();
+
+        // barycentric coordinate of intersection point u
+        let u = f * s.dot(h);
+        // barycentric coordinates have range (0, 1)
+        if u < 0. || u > 1. {
+            // the intersection is outside the triangle
+            return None;
+        }
+
+        let q = s.cross(edge1);
+        // barycentric coordinate of intersection point v
+        let v = f * ray.direction.dot(q);
+
+        // barycentric coordinates have range (0, 1)
+        // and their sum must not be greater than 1
+        if v < 0. || u + v > 1. {
+            // the intersection is outside the triangle
+            return None;
+        }
+
+        let t = f * edge2.dot(q);
+
+        if t > EPSILON {
+            let origin = ray.origin + ray.direction * t;
+
+            // this is not part of the Möller-Trumbore algorithm, the hit test spec
+            // requires it has an orientation such that the Y axis points along
+            // the triangle normal
+            let normal = edge1.cross(edge2).normalize();
+            let y = Vector3D::new(0., 1., 0.);
+            let dot = normal.dot(y);
+            let rotation = if dot > -EPSILON && dot < EPSILON {
+                // vectors are parallel, return the vector itself
+                // XXXManishearth it's possible for the vectors to be
+                // antiparallel, unclear if normals need to be flipped
+                Rotation3D::identity()
+            } else {
+                let axis = normal.cross(y);
+                let cos = normal.dot(y);
+                // This is Rotation3D::around_axis(axis.normalize(), theta), however
+                // that is just Rotation3D::quaternion(axis.normalize().xyz * sin, cos),
+                // which is Rotation3D::quaternion(cross, dot)
+                Rotation3D::quaternion(axis.x, axis.y, axis.z, cos)
+            };
+
+            return Some(RigidTransform3D::new(rotation, origin));
+        }
+
+        // triangle is behind ray
+        None
     }
 }

--- a/webxr-api/hittest.rs
+++ b/webxr-api/hittest.rs
@@ -24,6 +24,7 @@ pub enum EntityType {
 #[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
 /// https://immersive-web.github.io/hit-test/#dictdef-xrhittestoptionsinit
 pub struct HitTestSource {
+    pub id: HitTestId,
     pub space: Space,
     pub ray: Ray,
     pub types: EntityTypes,

--- a/webxr-api/hittest.rs
+++ b/webxr-api/hittest.rs
@@ -1,5 +1,7 @@
 use crate::ApiSpace;
+use crate::Native;
 use crate::Space;
+use euclid::RigidTransform3D;
 use euclid::Vector3D;
 use std::iter::FromIterator;
 
@@ -42,6 +44,18 @@ pub struct EntityTypes {
     pub plane: bool,
     pub mesh: bool,
 }
+
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+pub struct HitTestResult {
+    pub id: HitTestId,
+    pub space: RigidTransform3D<f32, HitTestSpace, Native>,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+/// The coordinate space of a hit test result
+pub struct HitTestSpace;
 
 impl EntityTypes {
     pub fn is_type(self, ty: EntityType) -> bool {

--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -57,8 +57,10 @@ pub use mock::MockDeviceMsg;
 pub use mock::MockDiscoveryAPI;
 pub use mock::MockInputInit;
 pub use mock::MockInputMsg;
+pub use mock::MockRegion;
 pub use mock::MockViewInit;
 pub use mock::MockViewsInit;
+pub use mock::MockWorld;
 
 pub use registry::MainThreadRegistry;
 pub use registry::MainThreadWaker;

--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -38,7 +38,9 @@ pub use frame::FrameUpdateEvent;
 pub use hittest::EntityType;
 pub use hittest::EntityTypes;
 pub use hittest::HitTestId;
+pub use hittest::HitTestResult;
 pub use hittest::HitTestSource;
+pub use hittest::HitTestSpace;
 pub use hittest::Ray;
 
 pub use input::Handedness;

--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -42,6 +42,7 @@ pub use hittest::HitTestResult;
 pub use hittest::HitTestSource;
 pub use hittest::HitTestSpace;
 pub use hittest::Ray;
+pub use hittest::Triangle;
 
 pub use input::Handedness;
 pub use input::InputFrame;

--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -14,10 +14,12 @@ mod device;
 mod error;
 mod events;
 mod frame;
+mod hittest;
 mod input;
 mod mock;
 mod registry;
 mod session;
+mod space;
 pub mod util;
 mod view;
 
@@ -32,6 +34,12 @@ pub use events::Visibility;
 
 pub use frame::Frame;
 pub use frame::FrameUpdateEvent;
+
+pub use hittest::EntityType;
+pub use hittest::EntityTypes;
+pub use hittest::HitTestId;
+pub use hittest::HitTestSource;
+pub use hittest::Ray;
 
 pub use input::Handedness;
 pub use input::InputFrame;
@@ -62,6 +70,10 @@ pub use session::SessionId;
 pub use session::SessionInit;
 pub use session::SessionMode;
 pub use session::SessionThread;
+
+pub use space::ApiSpace;
+pub use space::BaseSpace;
+pub use space::Space;
 
 pub use view::Display;
 pub use view::Floor;

--- a/webxr-api/mock.rs
+++ b/webxr-api/mock.rs
@@ -42,8 +42,9 @@ pub trait MockDiscoveryAPI<SwapChains>: 'static {
 #[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
 pub struct MockDeviceInit {
     pub floor_origin: Option<RigidTransform3D<f32, Floor, Native>>,
-    pub supports_immersive: bool,
-    pub supports_unbounded: bool,
+    pub supports_inline: bool,
+    pub supports_vr: bool,
+    pub supports_ar: bool,
     pub viewer_origin: Option<RigidTransform3D<f32, Viewer, Native>>,
     pub views: MockViewsInit,
     pub supported_features: Vec<String>,

--- a/webxr-api/mock.rs
+++ b/webxr-api/mock.rs
@@ -4,6 +4,7 @@
 
 use crate::DiscoveryAPI;
 use crate::Display;
+use crate::EntityType;
 use crate::Error;
 use crate::Floor;
 use crate::Handedness;
@@ -18,6 +19,7 @@ use crate::SelectEvent;
 use crate::SelectKind;
 use crate::Sender;
 use crate::TargetRayMode;
+use crate::Triangle;
 use crate::Viewer;
 use crate::Viewport;
 use crate::Visibility;
@@ -45,6 +47,7 @@ pub struct MockDeviceInit {
     pub viewer_origin: Option<RigidTransform3D<f32, Viewer, Native>>,
     pub views: MockViewsInit,
     pub supported_features: Vec<String>,
+    pub world: Option<MockWorld>,
 }
 
 #[derive(Clone, Debug)]
@@ -73,6 +76,8 @@ pub enum MockDeviceMsg {
     AddInputSource(MockInputInit),
     MessageInputSource(InputId, MockInputMsg),
     VisibilityChange(Visibility),
+    SetWorld(MockWorld),
+    ClearWorld,
     Disconnect(Sender<()>),
 }
 
@@ -98,4 +103,17 @@ pub enum MockInputMsg {
     TriggerSelect(SelectKind, SelectEvent),
     Disconnect,
     Reconnect,
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+pub struct MockRegion {
+    pub faces: Vec<Triangle>,
+    pub ty: EntityType,
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+pub struct MockWorld {
+    pub regions: Vec<MockRegion>,
 }

--- a/webxr-api/space.rs
+++ b/webxr-api/space.rs
@@ -1,0 +1,24 @@
+use crate::InputId;
+use euclid::RigidTransform3D;
+
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+/// A stand-in type for "the space isn't statically known since
+/// it comes from client side code"
+pub struct ApiSpace;
+
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+pub enum BaseSpace {
+    Local,
+    Floor,
+    Viewer,
+    Input(InputId),
+}
+
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+pub struct Space {
+    pub base: BaseSpace,
+    pub offset: RigidTransform3D<f32, ApiSpace, ApiSpace>,
+}

--- a/webxr-api/space.rs
+++ b/webxr-api/space.rs
@@ -13,7 +13,8 @@ pub enum BaseSpace {
     Local,
     Floor,
     Viewer,
-    Input(InputId),
+    TargetRay(InputId),
+    Grip(InputId),
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -36,7 +36,7 @@ profile = ["webxr-api/profile"]
 [dependencies]
 webxr-api = { path = "../webxr-api" }
 crossbeam-channel = "0.4"
-euclid = "0.20"
+euclid = "0.20.10"
 gleam = "0.9"
 glutin = { version = "0.21", optional = true }
 log = "0.4.6"

--- a/webxr/glwindow/mod.rs
+++ b/webxr/glwindow/mod.rs
@@ -142,6 +142,7 @@ impl DeviceAPI<Surface> for GlWindowDevice {
             events,
             time_ns,
             sent_time: 0,
+            hit_test_results: vec![],
         })
     }
 

--- a/webxr/googlevr/device.rs
+++ b/webxr/googlevr/device.rs
@@ -566,6 +566,7 @@ impl DeviceAPI<Surface> for GoogleVRDevice {
             events,
             time_ns,
             sent_time: 0,
+            hit_test_results: vec![],
         })
     }
 

--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -260,6 +260,7 @@ impl HeadlessDeviceData {
             events: vec![],
             time_ns,
             sent_time: 0,
+            hit_test_results: vec![],
         }
     }
 

--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -266,6 +266,8 @@ impl HeadlessDeviceData {
 
     fn handle_msg(&mut self, msg: MockDeviceMsg) -> bool {
         match msg {
+            MockDeviceMsg::SetWorld(_) => unimplemented!(),
+            MockDeviceMsg::ClearWorld => unimplemented!(),
             MockDeviceMsg::SetViewerOrigin(viewer_origin) => {
                 self.viewer_origin = viewer_origin;
             }

--- a/webxr/magicleap/mod.rs
+++ b/webxr/magicleap/mod.rs
@@ -425,6 +425,7 @@ impl Device for MagicLeapDevice {
             events,
             time_ns,
             sent_time: 0,
+            hit_test_result: vec![],
         })
     }
 

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -782,6 +782,7 @@ impl DeviceAPI<Surface> for OpenXrDevice {
             events,
             time_ns,
             sent_time: 0,
+            hit_test_results: vec![],
         };
 
         if let Some(right_select) = right.select {


### PR DESCRIPTION
Servo side: https://github.com/servo/servo/pull/26171

This adds support for all non-transient parts of he [WebXR Hit Test Module](https://immersive-web.github.io/hit-test), including mocking support.


This has not yet been hooked up to script and is thus completely untested.

r? @jdm