### PR TITLE
openxr: Add support for hand interaction extensions

### DIFF
--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -41,7 +41,7 @@ gleam = "0.9"
 glutin = { version = "0.21", optional = true }
 log = "0.4.6"
 gvr-sys = { version = "0.7", optional = true }
-openxr = { version = "0.9.1", optional = true }
+openxr = { version = "0.12.1", optional = true }
 serde = { version = "1.0", optional = true }
 surfman = { version = "0.1", features = ["sm-osmesa"] }
 surfman-chains = "0.3"

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -130,10 +130,8 @@ fn create_instance() -> Result<Instance, String> {
         engine_version: 1,
     };
 
-    let exts = ExtensionSet {
-        khr_d3d11_enable: true,
-        ..Default::default()
-    };
+    let mut exts = ExtensionSet::default();
+    exts.khr_d3d11_enable = true;
 
     entry
         .create_instance(&app_info, &exts)


### PR DESCRIPTION
This brings squeeze events to the hololens.

However, with this enabled all select events also trigger squeeze events, which isn't ideal (the paint demo is nearly unusable with this). A potential solution here is to only trigger squeeze when select is not triggered.

This might need to be discussed upstream in webxr (https://github.com/immersive-web/webxr/issues/997). Leaving PR open so we can land once we resolve this.