### PR TITLE
Workarounds for glwindow on macos

### DIFF
--- a/webxr-api/space.rs
+++ b/webxr-api/space.rs
@@ -16,7 +16,7 @@ pub enum BaseSpace {
     Viewer,
     TargetRay(InputId),
     Grip(InputId),
-    Joint(InputId, Joint)
+    Joint(InputId, Joint),
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
Fixes a panic on macos (https://github.com/servo/servo/issues/26340) and puts back blit mode, since for some reason the shaders don't render on macos.