### PR TITLE
Send eye positions per-view, relative to the native space

### DIFF
--- a/webxr-api/device.rs
+++ b/webxr-api/device.rs
@@ -19,10 +19,9 @@ use crate::Session;
 use crate::SessionBuilder;
 use crate::SessionInit;
 use crate::SessionMode;
-use crate::Viewport;
+use crate::Viewports;
 
 use euclid::RigidTransform3D;
-use euclid::Size2D;
 
 /// A trait for discovering XR devices
 pub trait DiscoveryAPI<SwapChains>: 'static {
@@ -40,9 +39,7 @@ pub trait DeviceAPI<Surface>: 'static {
     /// The transform from native coordinates to the floor.
     fn floor_transform(&self) -> Option<RigidTransform3D<f32, Native, Floor>>;
 
-    /// A resolution large enough to contain all the viewports.
-    /// https://immersive-web.github.io/webxr/#native-webgl-framebuffer-resolution
-    fn recommended_framebuffer_resolution(&self) -> Option<Size2D<i32, Viewport>>;
+    fn viewports(&self) -> Viewports;
 
     /// This method should block waiting for the next frame,
     /// and return the information for it.

--- a/webxr-api/device.rs
+++ b/webxr-api/device.rs
@@ -20,7 +20,6 @@ use crate::SessionBuilder;
 use crate::SessionInit;
 use crate::SessionMode;
 use crate::Viewport;
-use crate::Views;
 
 use euclid::RigidTransform3D;
 use euclid::Size2D;
@@ -41,23 +40,9 @@ pub trait DeviceAPI<Surface>: 'static {
     /// The transform from native coordinates to the floor.
     fn floor_transform(&self) -> Option<RigidTransform3D<f32, Native, Floor>>;
 
-    /// The transforms from viewer coordinates to the eyes, and their associated viewports.
-    fn views(&self) -> Views;
-
     /// A resolution large enough to contain all the viewports.
     /// https://immersive-web.github.io/webxr/#native-webgl-framebuffer-resolution
-    fn recommended_framebuffer_resolution(&self) -> Option<Size2D<i32, Viewport>> {
-        let viewport = match self.views() {
-            Views::Inline => return None,
-            Views::Mono(view) => view.viewport,
-            Views::Stereo(left, right) => left.viewport.union(&right.viewport),
-            Views::StereoCapture(left, right, third_eye) => left
-                .viewport
-                .union(&right.viewport)
-                .union(&third_eye.viewport),
-        };
-        Some(Size2D::new(viewport.max_x(), viewport.max_y()))
-    }
+    fn recommended_framebuffer_resolution(&self) -> Option<Size2D<i32, Viewport>>;
 
     /// This method should block waiting for the next frame,
     /// and return the information for it.

--- a/webxr-api/frame.rs
+++ b/webxr-api/frame.rs
@@ -24,6 +24,9 @@ pub struct Frame {
     /// This is the inverse of the view matrix.
     pub transform: Option<RigidTransform3D<f32, Viewer, Native>>,
 
+    // The various views
+    pub views: Views,
+
     /// Frame information for each connected input source
     pub inputs: Vec<InputFrame>,
 
@@ -43,7 +46,6 @@ pub struct Frame {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
 pub enum FrameUpdateEvent {
-    UpdateViews(Views),
     UpdateFloorTransform(Option<RigidTransform3D<f32, Native, Floor>>),
     HitTestSourceAdded(HitTestId),
 }

--- a/webxr-api/frame.rs
+++ b/webxr-api/frame.rs
@@ -19,15 +19,8 @@ use euclid::RigidTransform3D;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
 pub struct Frame {
-    /// The transform from the viewer to native coordinates
-    ///
-    /// This is equivalent to the pose of the viewer in native coordinates.
-    /// This is the inverse of the view matrix.
-    pub transform: Option<RigidTransform3D<f32, Viewer, Native>>,
-
-    // The various views
-    pub views: Views,
-
+    /// The pose information of the viewer
+    pub pose: Option<ViewerPose>,
     /// Frame information for each connected input source
     pub inputs: Vec<InputFrame>,
 
@@ -50,4 +43,17 @@ pub enum FrameUpdateEvent {
     UpdateFloorTransform(Option<RigidTransform3D<f32, Native, Floor>>),
     UpdateViewports(Viewports),
     HitTestSourceAdded(HitTestId),
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+pub struct ViewerPose {
+    /// The transform from the viewer to native coordinates
+    ///
+    /// This is equivalent to the pose of the viewer in native coordinates.
+    /// This is the inverse of the view matrix.
+    pub transform: RigidTransform3D<f32, Viewer, Native>,
+
+    // The various views
+    pub views: Views,
 }

--- a/webxr-api/frame.rs
+++ b/webxr-api/frame.rs
@@ -8,6 +8,7 @@ use crate::HitTestResult;
 use crate::InputFrame;
 use crate::Native;
 use crate::Viewer;
+use crate::Viewports;
 use crate::Views;
 
 use euclid::RigidTransform3D;
@@ -47,5 +48,6 @@ pub struct Frame {
 #[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
 pub enum FrameUpdateEvent {
     UpdateFloorTransform(Option<RigidTransform3D<f32, Native, Floor>>),
+    UpdateViewports(Viewports),
     HitTestSourceAdded(HitTestId),
 }

--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -35,6 +35,7 @@ pub use events::Visibility;
 
 pub use frame::Frame;
 pub use frame::FrameUpdateEvent;
+pub use frame::ViewerPose;
 
 pub use hand::Finger;
 pub use hand::FingerJoint;

--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -89,6 +89,7 @@ pub use space::ApiSpace;
 pub use space::BaseSpace;
 pub use space::Space;
 
+pub use view::Capture;
 pub use view::Display;
 pub use view::Floor;
 pub use view::Input;

--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -97,6 +97,7 @@ pub use view::RightEye;
 pub use view::View;
 pub use view::Viewer;
 pub use view::Viewport;
+pub use view::Viewports;
 pub use view::Views;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/webxr-api/session.rs
+++ b/webxr-api/session.rs
@@ -16,7 +16,9 @@ use crate::Receiver;
 use crate::Sender;
 use crate::SwapChainId;
 use crate::Viewport;
+use crate::Viewports;
 
+use euclid::Rect;
 use euclid::RigidTransform3D;
 use euclid::Size2D;
 
@@ -133,7 +135,7 @@ impl Quitter {
 #[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
 pub struct Session {
     floor_transform: Option<RigidTransform3D<f32, Native, Floor>>,
-    resolution: Option<Size2D<i32, Viewport>>,
+    viewports: Viewports,
     sender: Sender<SessionMsg>,
     environment_blend_mode: EnvironmentBlendMode,
     initial_inputs: Vec<InputSource>,
@@ -162,9 +164,19 @@ impl Session {
         self.environment_blend_mode
     }
 
-    pub fn recommended_framebuffer_resolution(&self) -> Size2D<i32, Viewport> {
-        self.resolution
-            .expect("Inline XR sessions should not construct a framebuffer")
+    pub fn viewports(&self) -> &[Rect<i32, Viewport>] {
+        &self.viewports.viewports
+    }
+
+    /// A resolution large enough to contain all the viewports.
+    /// https://immersive-web.github.io/webxr/#native-webgl-framebuffer-resolution
+    pub fn recommended_framebuffer_resolution(&self) -> Option<Size2D<i32, Viewport>> {
+        self.viewports()
+            .iter()
+            .fold(None::<Rect<_, _>>, |acc, vp| {
+                Some(acc.map(|a| a.union(vp)).unwrap_or(*vp))
+            })
+            .map(|rect| Size2D::new(rect.max_x(), rect.max_y()))
     }
 
     pub fn set_swap_chain(&mut self, swap_chain_id: Option<SwapChainId>) {
@@ -200,6 +212,7 @@ impl Session {
     pub fn apply_event(&mut self, event: FrameUpdateEvent) {
         match event {
             FrameUpdateEvent::UpdateFloorTransform(floor) => self.floor_transform = floor,
+            FrameUpdateEvent::UpdateViewports(vp) => self.viewports = vp,
             FrameUpdateEvent::HitTestSourceAdded(_) => (),
         }
     }
@@ -263,14 +276,14 @@ where
 
     pub fn new_session(&mut self) -> Session {
         let floor_transform = self.device.floor_transform();
-        let resolution = self.device.recommended_framebuffer_resolution();
+        let viewports = self.device.viewports();
         let sender = self.sender.clone();
         let initial_inputs = self.device.initial_inputs();
         let environment_blend_mode = self.device.environment_blend_mode();
         let granted_features = self.device.granted_features().into();
         Session {
             floor_transform,
-            resolution,
+            viewports,
             sender,
             initial_inputs,
             environment_blend_mode,

--- a/webxr-api/session.rs
+++ b/webxr-api/session.rs
@@ -16,7 +16,6 @@ use crate::Receiver;
 use crate::Sender;
 use crate::SwapChainId;
 use crate::Viewport;
-use crate::Views;
 
 use euclid::RigidTransform3D;
 use euclid::Size2D;
@@ -134,7 +133,6 @@ impl Quitter {
 #[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
 pub struct Session {
     floor_transform: Option<RigidTransform3D<f32, Native, Floor>>,
-    views: Views,
     resolution: Option<Size2D<i32, Viewport>>,
     sender: Sender<SessionMsg>,
     environment_blend_mode: EnvironmentBlendMode,
@@ -158,10 +156,6 @@ impl Session {
 
     pub fn initial_inputs(&self) -> &[InputSource] {
         &self.initial_inputs
-    }
-
-    pub fn views(&self) -> Views {
-        self.views.clone()
     }
 
     pub fn environment_blend_mode(&self) -> EnvironmentBlendMode {
@@ -205,7 +199,6 @@ impl Session {
 
     pub fn apply_event(&mut self, event: FrameUpdateEvent) {
         match event {
-            FrameUpdateEvent::UpdateViews(views) => self.views = views,
             FrameUpdateEvent::UpdateFloorTransform(floor) => self.floor_transform = floor,
             FrameUpdateEvent::HitTestSourceAdded(_) => (),
         }
@@ -270,7 +263,6 @@ where
 
     pub fn new_session(&mut self) -> Session {
         let floor_transform = self.device.floor_transform();
-        let views = self.device.views();
         let resolution = self.device.recommended_framebuffer_resolution();
         let sender = self.sender.clone();
         let initial_inputs = self.device.initial_inputs();
@@ -278,7 +270,6 @@ where
         let granted_features = self.device.granted_features().into();
         Session {
             floor_transform,
-            views,
             resolution,
             sender,
             initial_inputs,

--- a/webxr-api/session.rs
+++ b/webxr-api/session.rs
@@ -170,6 +170,8 @@ impl Session {
 
     /// A resolution large enough to contain all the viewports.
     /// https://immersive-web.github.io/webxr/#native-webgl-framebuffer-resolution
+    ///
+    /// Returns None if the session is inline
     pub fn recommended_framebuffer_resolution(&self) -> Option<Size2D<i32, Viewport>> {
         self.viewports()
             .iter()

--- a/webxr-api/view.rs
+++ b/webxr-api/view.rs
@@ -89,6 +89,15 @@ impl<Eye> Default for View<Eye> {
     }
 }
 
+impl<Eye> View<Eye> {
+    pub fn cast_unit<NewEye>(&self) -> View<NewEye> {
+        View {
+            transform: self.transform.cast_unit(),
+            projection: Transform3D::from_untyped(&self.projection.to_untyped()),
+            viewport: self.viewport.cast_unit(),
+        }
+    }
+}
 impl Views {
     pub fn recommended_framebuffer_resolution(&self) -> Option<Size2D<i32, Viewport>> {
         let viewport = match *self {

--- a/webxr-api/view.rs
+++ b/webxr-api/view.rs
@@ -65,15 +65,15 @@ pub enum Input {}
 #[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
 pub enum Capture {}
 
-/// For each eye, the transform from the viewer to that eye,
-/// its projection onto its display, and its display viewport.
+/// For each eye, the pose of that eye,
+/// its projection onto its display.
 /// For stereo displays, we have a `View<LeftEye>` and a `View<RightEye>`.
-/// For mono displays, we hagve a `View<Viewer>` (where the transform is the identity).
+/// For mono displays, we hagve a `View<Viewer>`
 /// https://immersive-web.github.io/webxr/#xrview
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
 pub struct View<Eye> {
-    pub transform: RigidTransform3D<f32, Viewer, Eye>,
+    pub transform: RigidTransform3D<f32, Eye, Native>,
     pub projection: Transform3D<f32, Eye, Display>,
 }
 

--- a/webxr-api/view.rs
+++ b/webxr-api/view.rs
@@ -6,6 +6,7 @@
 
 use euclid::Rect;
 use euclid::RigidTransform3D;
+use euclid::Size2D;
 use euclid::Transform3D;
 
 #[cfg(feature = "ipc")]
@@ -85,6 +86,21 @@ impl<Eye> Default for View<Eye> {
             projection: Transform3D::identity(),
             viewport: Default::default(),
         }
+    }
+}
+
+impl Views {
+    pub fn recommended_framebuffer_resolution(&self) -> Option<Size2D<i32, Viewport>> {
+        let viewport = match *self {
+            Views::Inline => return None,
+            Views::Mono(ref view) => view.viewport,
+            Views::Stereo(ref left, ref right) => left.viewport.union(&right.viewport),
+            Views::StereoCapture(ref left, ref right, ref third_eye) => left
+                .viewport
+                .union(&right.viewport)
+                .union(&third_eye.viewport),
+        };
+        Some(Size2D::new(viewport.max_x(), viewport.max_y()))
     }
 }
 

--- a/webxr/glwindow/mod.rs
+++ b/webxr/glwindow/mod.rs
@@ -51,6 +51,7 @@ use webxr_api::SessionInit;
 use webxr_api::SessionMode;
 use webxr_api::View;
 use webxr_api::Viewport;
+use webxr_api::Viewports;
 use webxr_api::Views;
 
 // How far off the ground are the viewer's eyes?
@@ -166,8 +167,14 @@ impl DeviceAPI<Surface> for GlWindowDevice {
         Some(RigidTransform3D::from_translation(translation))
     }
 
-    fn recommended_framebuffer_resolution(&self) -> Option<Size2D<i32, Viewport>> {
-        self.views().recommended_framebuffer_resolution()
+    fn viewports(&self) -> Viewports {
+        let size = self.viewport_size();
+        Viewports {
+            viewports: vec![
+                Rect::new(Point2D::default(), size),
+                Rect::new(Point2D::new(size.width, 0), size),
+            ],
+        }
     }
 
     fn wait_for_animation_frame(&mut self) -> Option<Frame> {
@@ -403,10 +410,6 @@ impl GlWindowDevice {
     }
 
     fn view<Eye>(&self, is_right: bool) -> View<Eye> {
-        let viewport_size = self.viewport_size();
-        let viewport_x_origin = if is_right { viewport_size.width } else { 0 };
-        let viewport_origin = Point2D::new(viewport_x_origin, 0);
-        let viewport = Rect::new(viewport_origin, viewport_size);
         let projection = self.perspective();
         let translation = if is_right {
             Vector3D::new(-INTER_PUPILLARY_DISTANCE / 2.0, 0.0, 0.0)
@@ -417,7 +420,6 @@ impl GlWindowDevice {
         View {
             transform,
             projection,
-            viewport,
         }
     }
 

--- a/webxr/glwindow/mod.rs
+++ b/webxr/glwindow/mod.rs
@@ -50,6 +50,7 @@ use webxr_api::Session;
 use webxr_api::SessionInit;
 use webxr_api::SessionMode;
 use webxr_api::View;
+use webxr_api::ViewerPose;
 use webxr_api::Viewport;
 use webxr_api::Viewports;
 use webxr_api::Views;
@@ -217,12 +218,14 @@ impl DeviceAPI<Surface> for GlWindowDevice {
             RigidTransform3D::from_translation(translation);
         let rotation = Rotation3D::from_untyped(&self.window.get_rotation());
         let rotation = RigidTransform3D::from_rotation(rotation);
-        let transform = Some(translation.post_transform(&rotation));
+        let transform = translation.post_transform(&rotation);
         Some(Frame {
-            transform,
+            pose: Some(ViewerPose {
+                transform,
+                views: self.views(),
+            }),
             inputs: vec![],
             events: vec![],
-            views: self.views(),
             time_ns,
             sent_time: 0,
             hit_test_results: vec![],

--- a/webxr/googlevr/device.rs
+++ b/webxr/googlevr/device.rs
@@ -18,7 +18,7 @@ use webxr_api::Sender;
 use webxr_api::TargetRayMode;
 use webxr_api::View;
 use webxr_api::Viewer;
-use webxr_api::Viewport;
+use webxr_api::Viewports;
 use webxr_api::Views;
 
 use crate::gles as gl;
@@ -402,18 +402,9 @@ impl GoogleVRDevice {
         // only translation
         let transform = decompose_rigid(&eye_mat).inverse();
 
-        let size = Size2D::new(self.render_size.width / 2, self.render_size.height);
-        let origin = if eye == gvr::gvr_eye::GVR_LEFT_EYE {
-            Point2D::origin()
-        } else {
-            Point2D::new(self.render_size.width / 2, 0)
-        };
-        let viewport = Rect::new(origin, size);
-
         View {
             projection,
             transform,
-            viewport,
         }
     }
 
@@ -596,8 +587,14 @@ impl DeviceAPI<Surface> for GoogleVRDevice {
         Some(RigidTransform3D::identity())
     }
 
-    fn recommended_framebuffer_resolution(&self) -> Option<Size2D<i32, Viewport>> {
-        self.views().recommended_framebuffer_resolution()
+    fn viewports(&self) -> Viewports {
+        let size = Size2D::new(self.render_size.width / 2, self.render_size.height);
+        Viewports {
+            viewports: vec![
+                Rect::new(Point2D::origin(), size),
+                Rect::new(Point2D::new(size.width, 0), size),
+            ],
+        }
     }
 
     fn wait_for_animation_frame(&mut self) -> Option<Frame> {

--- a/webxr/googlevr/device.rs
+++ b/webxr/googlevr/device.rs
@@ -18,6 +18,7 @@ use webxr_api::Sender;
 use webxr_api::TargetRayMode;
 use webxr_api::View;
 use webxr_api::Viewer;
+use webxr_api::ViewerPose;
 use webxr_api::Viewports;
 use webxr_api::Views;
 
@@ -605,9 +606,11 @@ impl DeviceAPI<Surface> for GoogleVRDevice {
 
         // Predict head matrix
         Some(Frame {
-            transform: Some(self.fetch_head_matrix()),
+            pose: Some(ViewerPose {
+                transform: self.fetch_head_matrix(),
+                views: self.views(),
+            }),
             inputs: self.input_state(),
-            views: self.views(),
             events: vec![],
             time_ns,
             sent_time: 0,

--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -43,6 +43,7 @@ use webxr_api::SessionMode;
 use webxr_api::Space;
 use webxr_api::View;
 use webxr_api::Viewer;
+use webxr_api::ViewerPose;
 use webxr_api::Viewports;
 use webxr_api::Views;
 
@@ -323,7 +324,10 @@ macro_rules! with_all_sessions {
 impl HeadlessDeviceData {
     fn get_frame(&self, session: &PerSessionData) -> Frame {
         let time_ns = time::precise_time_ns();
-        let transform = self.viewer_origin;
+        let pose = self.viewer_origin.map(|transform| ViewerPose {
+            transform,
+            views: self.views(session),
+        });
         let inputs = self
             .inputs
             .iter()
@@ -339,10 +343,9 @@ impl HeadlessDeviceData {
             .collect();
 
         Frame {
-            transform,
+            pose,
             inputs,
             events: vec![],
-            views: self.views(session),
             time_ns,
             sent_time: 0,
             hit_test_results: vec![],

--- a/webxr/magicleap/mod.rs
+++ b/webxr/magicleap/mod.rs
@@ -204,13 +204,12 @@ impl MagicLeapDevice {
 
 impl MagicLeapDevice {
     fn views(&self) -> Views {
-        let lerped = self.lerp_transforms();
         let left = View {
-            transform: self.transform(0).inverse().pre_transform(&lerped),
+            transform: self.transform(0),
             projection: self.projection(0),
         };
         let right = View {
-            transform: self.transform(1).inverse().pre_transform(&lerped),
+            transform: self.transform(1),
             projection: self.projection(1),
         };
         Views::Stereo(left, right)

--- a/webxr/magicleap/mod.rs
+++ b/webxr/magicleap/mod.rs
@@ -82,6 +82,7 @@ use webxr_api::SessionInit;
 use webxr_api::SessionMode;
 use webxr_api::View;
 use webxr_api::Viewer;
+use webxr_api::ViewerPose;
 use webxr_api::Viewport;
 use webxr_api::Viewports;
 use webxr_api::Views;
@@ -426,7 +427,7 @@ impl Device for MagicLeapDevice {
         }
         let time_ns = time::precise_time_ns();
 
-        let transform = Some(self.lerp_transforms());
+        let transform = self.lerp_transforms();
         let inputs = Vec::new();
         let events = if self.view_update_needed {
             vec![FrameUpdateEvent::UpdateViews(self.views())]
@@ -434,10 +435,12 @@ impl Device for MagicLeapDevice {
             vec![]
         };
         Some(Frame {
-            transform,
+            pose: Some(ViewerPose {
+                transform,
+                views: self.views(),
+            }),
             inputs,
             events,
-            views: self.views(),
             time_ns,
             sent_time: 0,
             hit_test_result: vec![],

--- a/webxr/magicleap/mod.rs
+++ b/webxr/magicleap/mod.rs
@@ -83,6 +83,7 @@ use webxr_api::SessionMode;
 use webxr_api::View;
 use webxr_api::Viewer;
 use webxr_api::Viewport;
+use webxr_api::Viewports;
 use webxr_api::Views;
 
 mod magicleap_c_api;
@@ -206,12 +207,10 @@ impl MagicLeapDevice {
         let left = View {
             transform: self.transform(0).inverse().pre_transform(&lerped),
             projection: self.projection(0),
-            viewport: self.viewport(0),
         };
         let right = View {
             transform: self.transform(1).inverse().pre_transform(&lerped),
             projection: self.projection(1),
-            viewport: self.viewport(1),
         };
         Views::Stereo(left, right)
     }
@@ -445,8 +444,10 @@ impl Device for MagicLeapDevice {
         })
     }
 
-    fn recommended_framebuffer_resolution(&self) -> Option<Size2D<i32, Viewport>> {
-        self.views().recommended_framebuffer_resolution()
+    fn viewports(&self) -> Viewports {
+        Viewports {
+            viewports: vec![self.viewports(0), self.viewports(1)],
+        }
     }
 
     fn render_animation_frame(&mut self, surface: Surface) -> Surface {

--- a/webxr/openxr/input.rs
+++ b/webxr/openxr/input.rs
@@ -2,7 +2,7 @@ use euclid::RigidTransform3D;
 use openxr::d3d::D3D11;
 use openxr::{
     self, Action, ActionSet, Binding, FrameState, Hand as HandEnum, HandJoint, HandTracker,
-    Instance, Path, Posef, Quaternionf, Session, Space, SpaceLocationFlags, Vector3f,
+    Instance, Path, Posef, Session, Space, SpaceLocationFlags,
 };
 use webxr_api::Finger;
 use webxr_api::Hand;
@@ -16,6 +16,8 @@ use webxr_api::Native;
 use webxr_api::SelectEvent;
 use webxr_api::TargetRayMode;
 use webxr_api::Viewer;
+
+use super::IDENTITY_POSE;
 
 /// Number of frames to wait with the menu gesture before
 /// opening the menu.
@@ -72,19 +74,6 @@ impl ClickState {
     }
 }
 
-const IDENTITY_POSE: Posef = Posef {
-    orientation: Quaternionf {
-        x: 0.,
-        y: 0.,
-        z: 0.,
-        w: 1.,
-    },
-    position: Vector3f {
-        x: 0.,
-        y: 0.,
-        z: 0.,
-    },
-};
 pub struct OpenXRInput {
     id: InputId,
     action_aim_pose: Action<Posef>,

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -46,6 +46,7 @@ use webxr_api::SessionId;
 use webxr_api::SessionInit;
 use webxr_api::SessionMode;
 use webxr_api::View;
+use webxr_api::ViewerPose;
 use webxr_api::Viewports;
 use webxr_api::Views;
 use webxr_api::Visibility;
@@ -1127,10 +1128,9 @@ impl DeviceAPI<Surface> for OpenXrDevice {
         }
 
         let frame = Frame {
-            transform: Some(transform),
+            pose: Some(ViewerPose { transform, views }),
             inputs: vec![right.frame, left.frame],
             events: vec![],
-            views,
             time_ns,
             sent_time: 0,
             hit_test_results: vec![],

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -18,10 +18,10 @@ use openxr::{
     SecondaryEndInfo, Session, Space, Swapchain, SwapchainCreateFlags, SwapchainCreateInfo,
     SwapchainUsageFlags, SystemId, Vector3f, ViewConfigurationType,
 };
-use std::{cmp, mem};
-use std::sync::{Arc, Mutex};
-use std::{thread, time::Duration};
 use std::ptr;
+use std::sync::{Arc, Mutex};
+use std::{cmp, mem};
+use std::{thread, time::Duration};
 use surfman::Adapter;
 use surfman::Device as SurfmanDevice;
 use surfman::Surface;
@@ -49,10 +49,10 @@ use webxr_api::SessionMode;
 use webxr_api::View;
 use webxr_api::Views;
 use webxr_api::Visibility;
-use winapi::Interface;
 use winapi::shared::dxgi;
 use winapi::shared::dxgiformat;
 use winapi::shared::winerror::{DXGI_ERROR_NOT_FOUND, S_OK};
+use winapi::Interface;
 use wio::com::ComPtr;
 
 mod input;

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -313,6 +313,7 @@ struct OpenXrDevice {
     granted_features: Vec<String>,
     context_menu_provider: Box<dyn ContextMenuProvider>,
     context_menu_future: Option<Box<dyn ContextMenuFuture>>,
+    resolution: Size2D<i32, Viewport>,
 }
 
 /// Data that is shared between the openxr thread and the
@@ -808,6 +809,7 @@ impl OpenXrDevice {
             granted_features,
             context_menu_provider,
             context_menu_future: None,
+            resolution: Size2D::new(sw_width as i32, sw_height as i32),
         })
     }
 
@@ -984,7 +986,7 @@ impl DeviceAPI<Surface> for OpenXrDevice {
     }
 
     fn recommended_framebuffer_resolution(&self) -> Option<Size2D<i32, Viewport>> {
-        self.views().recommended_framebuffer_resolution()
+        Some(self.resolution)
     }
 
     fn wait_for_animation_frame(&mut self) -> Option<Frame> {


### PR DESCRIPTION
Fixes https://github.com/servo/webxr/issues/173

This contains many related changes:

 - Makes the views state per-frame
 - Makes viewports no longer part of the views state, and only occasionally updated
 - Switches view transforms to being native-relative (and related cleanups in openxr, reducing the number of `locate_views` calls)
 - Caching of projection matrices in openxr
 - Cleanups of the headless backend to support multiple sessions on the same device (only relevant for inline)

Overall this should improve stability with a _tiny_ performance win from not doing as much space-locating each frame.

servo side: https://github.com/servo/servo/pull/26551