### PR TITLE
Added API for layer management

### DIFF
--- a/webxr-api/Cargo.toml
+++ b/webxr-api/Cargo.toml
@@ -24,7 +24,6 @@ profile = ["time"]
 
 [dependencies]
 euclid = "0.20"
-surfman-chains-api = "0.2"
 ipc-channel = { version = "0.14", optional = true }
 log = "0.4"
 serde = { version = "1.0", optional = true }

--- a/webxr-api/error.rs
+++ b/webxr-api/error.rs
@@ -14,6 +14,8 @@ use serde::{Deserialize, Serialize};
 pub enum Error {
     NoMatchingDevice,
     CommunicationError,
+    ThreadCreationError,
+    InlineSession,
     UnsupportedFeature(String),
     BackendSpecific(String),
 }

--- a/webxr-api/frame.rs
+++ b/webxr-api/frame.rs
@@ -7,6 +7,7 @@ use crate::HitTestId;
 use crate::HitTestResult;
 use crate::InputFrame;
 use crate::Native;
+use crate::SubImages;
 use crate::Viewer;
 use crate::Viewports;
 use crate::Views;
@@ -26,6 +27,9 @@ pub struct Frame {
 
     /// Events that occur with the frame.
     pub events: Vec<FrameUpdateEvent>,
+
+    /// The subimages to render to
+    pub sub_images: Vec<SubImages>,
 
     /// Value of time::precise_time_ns() when frame was obtained
     pub time_ns: u64,

--- a/webxr-api/layer.rs
+++ b/webxr-api/layer.rs
@@ -1,0 +1,295 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::Error;
+use crate::Viewport;
+use crate::Viewports;
+
+use euclid::Rect;
+use euclid::Size2D;
+
+use std::fmt::Debug;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "ipc", derive(Deserialize, Serialize))]
+pub struct ContextId(pub u64);
+
+#[cfg(feature = "ipc")]
+use serde::{Deserialize, Serialize};
+
+pub trait GLTypes {
+    type Device;
+    type Context;
+    type Bindings;
+}
+
+pub trait GLContexts<GL: GLTypes> {
+    fn bindings(&mut self, device: &GL::Device, context_id: ContextId) -> Option<&GL::Bindings>;
+    fn context(&mut self, device: &GL::Device, context_id: ContextId) -> Option<&mut GL::Context>;
+}
+
+impl GLTypes for () {
+    type Bindings = ();
+    type Device = ();
+    type Context = ();
+}
+
+impl GLContexts<()> for () {
+    fn context(&mut self, _: &(), _: ContextId) -> Option<&mut ()> {
+        Some(self)
+    }
+
+    fn bindings(&mut self, _: &(), _: ContextId) -> Option<&()> {
+        Some(self)
+    }
+}
+
+pub trait LayerGrandManagerAPI<GL: GLTypes> {
+    fn create_layer_manager(&self, factory: LayerManagerFactory<GL>)
+        -> Result<LayerManager, Error>;
+
+    fn clone_layer_grand_manager(&self) -> LayerGrandManager<GL>;
+}
+
+pub struct LayerGrandManager<GL>(Box<dyn Send + LayerGrandManagerAPI<GL>>);
+
+impl<GL: GLTypes> Clone for LayerGrandManager<GL> {
+    fn clone(&self) -> Self {
+        self.0.clone_layer_grand_manager()
+    }
+}
+
+impl<GL> Debug for LayerGrandManager<GL> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        "LayerGrandManager(...)".fmt(fmt)
+    }
+}
+
+impl<GL: GLTypes> LayerGrandManager<GL> {
+    pub fn new<GM>(grand_manager: GM) -> LayerGrandManager<GL>
+    where
+        GM: 'static + Send + LayerGrandManagerAPI<GL>,
+    {
+        LayerGrandManager(Box::new(grand_manager))
+    }
+
+    pub fn create_layer_manager<F, M>(&self, factory: F) -> Result<LayerManager, Error>
+    where
+        F: 'static + Send + FnOnce(&mut GL::Device, &mut dyn GLContexts<GL>) -> Result<M, Error>,
+        M: 'static + LayerManagerAPI<GL>,
+    {
+        self.0
+            .create_layer_manager(LayerManagerFactory::new(factory))
+    }
+}
+
+pub trait LayerManagerAPI<GL: GLTypes> {
+    fn create_layer(
+        &mut self,
+        device: &mut GL::Device,
+        context: &mut GL::Context,
+        context_id: ContextId,
+        init: LayerInit,
+    ) -> Result<LayerId, Error>;
+
+    fn destroy_layer(
+        &mut self,
+        device: &mut GL::Device,
+        context: &mut GL::Context,
+        context_id: ContextId,
+        layer_id: LayerId,
+    );
+
+    fn layers(&self) -> &[(ContextId, LayerId)];
+
+    fn begin_frame(
+        &mut self,
+        device: &mut GL::Device,
+        contexts: &mut dyn GLContexts<GL>,
+        layers: &[(ContextId, LayerId)],
+    ) -> Result<Vec<SubImages>, Error>;
+
+    fn end_frame(
+        &mut self,
+        device: &mut GL::Device,
+        contexts: &mut dyn GLContexts<GL>,
+        layers: &[(ContextId, LayerId)],
+    ) -> Result<(), Error>;
+}
+
+pub struct LayerManager(Box<dyn Send + LayerManagerAPI<()>>);
+
+impl Debug for LayerManager {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        "LayerManager(...)".fmt(fmt)
+    }
+}
+
+impl LayerManager {
+    pub fn create_layer(
+        &mut self,
+        context_id: ContextId,
+        init: LayerInit,
+    ) -> Result<LayerId, Error> {
+        self.0.create_layer(&mut (), &mut (), context_id, init)
+    }
+
+    pub fn destroy_layer(&mut self, context_id: ContextId, layer_id: LayerId) {
+        self.0.destroy_layer(&mut (), &mut (), context_id, layer_id);
+    }
+
+    pub fn begin_frame(
+        &mut self,
+        layers: &[(ContextId, LayerId)],
+    ) -> Result<Vec<SubImages>, Error> {
+        self.0.begin_frame(&mut (), &mut (), layers)
+    }
+
+    pub fn end_frame(&mut self, layers: &[(ContextId, LayerId)]) -> Result<(), Error> {
+        self.0.end_frame(&mut (), &mut (), layers)
+    }
+}
+
+impl LayerManager {
+    pub fn new<M>(manager: M) -> LayerManager
+    where
+        M: 'static + Send + LayerManagerAPI<()>,
+    {
+        LayerManager(Box::new(manager))
+    }
+}
+
+impl Drop for LayerManager {
+    fn drop(&mut self) {
+        log::debug!("Dropping LayerManager");
+        for (context_id, layer_id) in self.0.layers().to_vec() {
+            self.destroy_layer(context_id, layer_id);
+        }
+    }
+}
+
+pub struct LayerManagerFactory<GL: GLTypes>(
+    Box<
+        dyn Send
+            + FnOnce(
+                &mut GL::Device,
+                &mut dyn GLContexts<GL>,
+            ) -> Result<Box<dyn LayerManagerAPI<GL>>, Error>,
+    >,
+);
+
+impl<GL: GLTypes> Debug for LayerManagerFactory<GL> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        "LayerManagerFactory(...)".fmt(fmt)
+    }
+}
+
+impl<GL: GLTypes> LayerManagerFactory<GL> {
+    pub fn new<F, M>(factory: F) -> LayerManagerFactory<GL>
+    where
+        F: 'static + Send + FnOnce(&mut GL::Device, &mut dyn GLContexts<GL>) -> Result<M, Error>,
+        M: 'static + LayerManagerAPI<GL>,
+    {
+        LayerManagerFactory(Box::new(move |device, contexts| {
+            Ok(Box::new(factory(device, contexts)?))
+        }))
+    }
+
+    pub fn build(
+        self,
+        device: &mut GL::Device,
+        contexts: &mut dyn GLContexts<GL>,
+    ) -> Result<Box<dyn LayerManagerAPI<GL>>, Error> {
+        (self.0)(device, contexts)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "ipc", derive(Deserialize, Serialize))]
+pub struct LayerId(usize);
+
+static NEXT_LAYER_ID: AtomicUsize = AtomicUsize::new(0);
+
+impl LayerId {
+    pub fn new() -> LayerId {
+        LayerId(NEXT_LAYER_ID.fetch_add(1, Ordering::SeqCst))
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "ipc", derive(Deserialize, Serialize))]
+pub enum LayerInit {
+    // https://www.w3.org/TR/webxr/#dictdef-xrwebgllayerinit
+    WebGLLayer {
+        antialias: bool,
+        depth: bool,
+        stencil: bool,
+        alpha: bool,
+        ignore_depth_values: bool,
+        framebuffer_scale_factor: f32,
+    },
+    // https://immersive-web.github.io/layers/#xrprojectionlayerinittype
+    ProjectionLayer {
+        depth: bool,
+        stencil: bool,
+        alpha: bool,
+        scale_factor: f32,
+    },
+    // TODO: other layer types
+}
+
+impl LayerInit {
+    pub fn texture_size(&self, viewports: &Viewports) -> Size2D<i32, Viewport> {
+        match self {
+            LayerInit::WebGLLayer {
+                framebuffer_scale_factor: scale,
+                ..
+            }
+            | LayerInit::ProjectionLayer {
+                scale_factor: scale,
+                ..
+            } => {
+                let native_size = viewports
+                    .viewports
+                    .iter()
+                    .fold(Rect::zero(), |acc, view| acc.union(view))
+                    .size;
+                (native_size.to_f32() * *scale).to_i32()
+            }
+        }
+    }
+}
+
+/// https://immersive-web.github.io/layers/#enumdef-xrlayerlayout
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "ipc", derive(Deserialize, Serialize))]
+pub enum LayerLayout {
+    // TODO: Default
+    // Allocates one texture
+    Mono,
+    // Allocates one texture, which is split in half vertically, giving two subimages
+    StereoLeftRight,
+    // Allocates one texture, which is split in half horizonally, giving two subimages
+    StereoTopBottom,
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "ipc", derive(Deserialize, Serialize))]
+pub struct SubImages {
+    pub layer_id: LayerId,
+    pub sub_image: Option<SubImage>,
+    pub view_sub_images: Vec<SubImage>,
+}
+
+/// https://immersive-web.github.io/layers/#xrsubimagetype
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "ipc", derive(Deserialize, Serialize))]
+pub struct SubImage {
+    pub color_texture: u32,
+    pub depth_stencil_texture: Option<u32>,
+    pub texture_array_index: Option<u32>,
+    pub viewport: Rect<i32, Viewport>,
+}

--- a/webxr-api/lib.rs
+++ b/webxr-api/lib.rs
@@ -4,12 +4,6 @@
 
 //! This crate defines the Rust API for WebXR. It is implemented by the `webxr` crate.
 
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
-
-#[cfg(feature = "ipc")]
-use serde::{Deserialize, Serialize};
-
 mod device;
 mod error;
 mod events;
@@ -17,6 +11,7 @@ mod frame;
 mod hand;
 mod hittest;
 mod input;
+mod layer;
 mod mock;
 mod registry;
 mod session;
@@ -61,6 +56,20 @@ pub use input::SelectEvent;
 pub use input::SelectKind;
 pub use input::TargetRayMode;
 
+pub use layer::ContextId;
+pub use layer::GLContexts;
+pub use layer::GLTypes;
+pub use layer::LayerGrandManager;
+pub use layer::LayerGrandManagerAPI;
+pub use layer::LayerId;
+pub use layer::LayerInit;
+pub use layer::LayerLayout;
+pub use layer::LayerManager;
+pub use layer::LayerManagerAPI;
+pub use layer::LayerManagerFactory;
+pub use layer::SubImage;
+pub use layer::SubImages;
+
 pub use mock::MockDeviceInit;
 pub use mock::MockDeviceMsg;
 pub use mock::MockDiscoveryAPI;
@@ -101,19 +110,6 @@ pub use view::Viewer;
 pub use view::Viewport;
 pub use view::Viewports;
 pub use view::Views;
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
-pub struct SwapChainId(usize);
-
-impl SwapChainId {
-    pub fn new() -> Self {
-        let id = NEXT_SWAP_CHAIN_ID.fetch_add(1, Ordering::SeqCst);
-        Self(id)
-    }
-}
-
-static NEXT_SWAP_CHAIN_ID: AtomicUsize = AtomicUsize::new(0);
 
 #[cfg(feature = "ipc")]
 use std::thread;

--- a/webxr-api/mock.rs
+++ b/webxr-api/mock.rs
@@ -30,12 +30,12 @@ use euclid::{Rect, RigidTransform3D, Transform3D};
 use serde::{Deserialize, Serialize};
 
 /// A trait for discovering mock XR devices
-pub trait MockDiscoveryAPI<SwapChains>: 'static {
+pub trait MockDiscoveryAPI<GL>: 'static {
     fn simulate_device_connection(
         &mut self,
         init: MockDeviceInit,
         receiver: Receiver<MockDeviceMsg>,
-    ) -> Result<Box<dyn DiscoveryAPI<SwapChains>>, Error>;
+    ) -> Result<Box<dyn DiscoveryAPI<GL>>, Error>;
 }
 
 #[derive(Clone, Debug)]

--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -36,13 +36,13 @@ profile = ["webxr-api/profile"]
 webxr-api = { path = "../webxr-api" }
 crossbeam-channel = "0.4"
 euclid = "0.20.10"
-gleam = "0.9"
 log = "0.4.6"
 gvr-sys = { version = "0.7", optional = true }
 openxr = { git = "https://github.com/servo/openxrs.git", branch="xr-msft", optional = true }
 serde = { version = "1.0", optional = true }
-surfman = { git = "https://github.com/servo/surfman", features = ["sm-x11"] }
-surfman-chains = { git = "https://github.com/asajeffrey/surfman-chains" }
+sparkle = "0.1"
+surfman = { version = "0.3", features = ["sm-x11"] }
+surfman-chains = "0.4"
 time = "0.1.42"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/webxr/lib.rs
+++ b/webxr/lib.rs
@@ -28,14 +28,8 @@ mod egl;
 #[cfg(feature = "openxr-api")]
 pub mod openxr;
 
-/// A type synonym for swap chains
-pub type SwapChains = surfman_chains::SwapChains<webxr_api::SwapChainId, surfman::Device>;
-
-/// A type synonym for the main thread registry
-pub type MainThreadRegistry = webxr_api::MainThreadRegistry<SwapChains>;
-
-/// A type synonym for the session builder
-pub type SessionBuilder<'a> = webxr_api::SessionBuilder<'a, SwapChains>;
-
-/// A type synonym for discovery objects
-pub type Discovery = Box<dyn webxr_api::DiscoveryAPI<SwapChains>>;
+pub mod surfman_layer_manager;
+pub use surfman_layer_manager::SurfmanGL;
+pub use surfman_layer_manager::SurfmanLayerManager;
+pub type MainThreadRegistry = webxr_api::MainThreadRegistry<surfman_layer_manager::SurfmanGL>;
+pub type Discovery = Box<dyn webxr_api::DiscoveryAPI<SurfmanGL>>;

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -1,5 +1,4 @@
-use crate::SessionBuilder;
-use crate::SwapChains;
+use crate::SurfmanGL;
 
 use euclid::Point2D;
 use euclid::Rect;
@@ -18,17 +17,22 @@ use openxr::{
     SecondaryEndInfo, Session, Space, Swapchain, SwapchainCreateFlags, SwapchainCreateInfo,
     SwapchainUsageFlags, SystemId, Vector3f, ViewConfigurationType,
 };
+use std::collections::HashMap;
+use std::mem;
+use std::ops::Deref;
 use std::ptr;
 use std::sync::{Arc, Mutex};
-use std::{cmp, mem};
-use std::{thread, time::Duration};
-use surfman::Adapter;
+use std::thread;
+use std::time::Duration;
+use surfman::Adapter as SurfmanAdapter;
+use surfman::Context as SurfmanContext;
 use surfman::Device as SurfmanDevice;
-use surfman::Surface;
-use surfman_chains::SurfaceProvider;
+use surfman::Error as SurfmanError;
+use surfman::SurfaceTexture;
 use webxr_api;
 use webxr_api::util::{self, ClipPlanes};
 use webxr_api::Capture;
+use webxr_api::ContextId;
 use webxr_api::DeviceAPI;
 use webxr_api::DiscoveryAPI;
 use webxr_api::Display;
@@ -37,8 +41,14 @@ use webxr_api::Event;
 use webxr_api::EventBuffer;
 use webxr_api::Floor;
 use webxr_api::Frame;
+use webxr_api::GLContexts;
 use webxr_api::InputId;
 use webxr_api::InputSource;
+use webxr_api::LayerGrandManager;
+use webxr_api::LayerId;
+use webxr_api::LayerInit;
+use webxr_api::LayerManager;
+use webxr_api::LayerManagerAPI;
 use webxr_api::LeftEye;
 use webxr_api::Native;
 use webxr_api::Quitter;
@@ -46,11 +56,14 @@ use webxr_api::RightEye;
 use webxr_api::SelectKind;
 use webxr_api::Sender;
 use webxr_api::Session as WebXrSession;
-use webxr_api::SessionId;
+use webxr_api::SessionBuilder;
 use webxr_api::SessionInit;
 use webxr_api::SessionMode;
+use webxr_api::SubImage;
+use webxr_api::SubImages;
 use webxr_api::View;
 use webxr_api::ViewerPose;
+use webxr_api::Viewport;
 use webxr_api::Viewports;
 use webxr_api::Views;
 use webxr_api::Visibility;
@@ -93,18 +106,10 @@ const VIEW_INIT: openxr::View = openxr::View {
 // Disabled by default to reduce texture sizes
 // XXXManishearth we can make this into a pref
 const SECONDARY_VIEW_ENABLED: bool = false;
+
 // How much to downscale the view capture by.
+// This is used for performance reasons, to dedicate less texture memory to the camera.
 const SECONDARY_VIEW_DOWNSCALE: u32 = 2;
-
-pub trait GlThread: Send {
-    fn execute(&self, runnable: Box<dyn FnOnce(&SurfmanDevice) + Send>);
-    fn clone(&self) -> Box<dyn GlThread>;
-}
-
-pub trait SurfaceProviderRegistration: Send {
-    fn register(&self, id: SessionId, provider: Box<dyn SurfaceProvider<SurfmanDevice> + Send>);
-    fn clone(&self) -> Box<dyn SurfaceProviderRegistration>;
-}
 
 /// Provides a way to spawn and interact with context menus
 pub trait ContextMenuProvider: Send {
@@ -177,20 +182,12 @@ impl Drop for OpenXrDevice {
 }
 
 pub struct OpenXrDiscovery {
-    gl_thread: Box<dyn GlThread>,
-    provider_registration: Box<dyn SurfaceProviderRegistration>,
     context_menu_provider: Box<dyn ContextMenuProvider>,
 }
 
 impl OpenXrDiscovery {
-    pub fn new(
-        gl_thread: Box<dyn GlThread>,
-        provider_registration: Box<dyn SurfaceProviderRegistration>,
-        context_menu_provider: Box<dyn ContextMenuProvider>,
-    ) -> Self {
+    pub fn new(context_menu_provider: Box<dyn ContextMenuProvider>) -> Self {
         Self {
-            gl_thread,
-            provider_registration,
             context_menu_provider,
         }
     }
@@ -286,7 +283,7 @@ fn get_matching_adapter(
     }
 }
 
-pub fn create_surfman_adapter() -> Option<Adapter> {
+pub fn create_surfman_adapter() -> Option<SurfmanAdapter> {
     let instance = create_instance(false).ok()?;
     let system = instance
         .instance
@@ -295,7 +292,7 @@ pub fn create_surfman_adapter() -> Option<Adapter> {
 
     let requirements = D3D11::requirements(&instance.instance, system).ok()?;
     let adapter = get_matching_adapter(&requirements).ok()?;
-    Some(Adapter::from_dxgi_adapter(adapter.up()))
+    Some(SurfmanAdapter::from_dxgi_adapter(adapter.up()))
 }
 
 fn pick_format(formats: &[dxgiformat::DXGI_FORMAT]) -> dxgiformat::DXGI_FORMAT {
@@ -316,16 +313,14 @@ fn pick_format(formats: &[dxgiformat::DXGI_FORMAT]) -> dxgiformat::DXGI_FORMAT {
     panic!("No formats supported amongst {:?}", formats);
 }
 
-impl DiscoveryAPI<SwapChains> for OpenXrDiscovery {
+impl DiscoveryAPI<SurfmanGL> for OpenXrDiscovery {
     fn request_session(
         &mut self,
         mode: SessionMode,
         init: &SessionInit,
-        xr: SessionBuilder,
+        xr: SessionBuilder<SurfmanGL>,
     ) -> Result<WebXrSession, Error> {
         if self.supports_session(mode) {
-            let gl_thread = self.gl_thread.clone();
-            let provider_registration = self.provider_registration.clone();
             let needs_hands = init.feature_requested("hand-tracking");
             let instance = create_instance(needs_hands).map_err(|e| Error::BackendSpecific(e))?;
 
@@ -335,16 +330,13 @@ impl DiscoveryAPI<SwapChains> for OpenXrDiscovery {
             }
 
             let granted_features = init.validate(mode, &supported_features)?;
-            let id = xr.id();
             let context_menu_provider = self.context_menu_provider.clone_object();
-            xr.spawn(move || {
+            xr.spawn(move |grand_manager| {
                 OpenXrDevice::new(
-                    gl_thread,
-                    provider_registration,
                     instance,
                     granted_features,
-                    id,
                     context_menu_provider,
+                    grand_manager,
                 )
             })
         } else {
@@ -358,16 +350,14 @@ impl DiscoveryAPI<SwapChains> for OpenXrDiscovery {
 }
 
 struct OpenXrDevice {
-    session: Session<D3D11>,
+    session: Arc<Session<D3D11>>,
     instance: Instance,
     events: EventBuffer,
     frame_waiter: FrameWaiter,
-    shared_data: Arc<Mutex<SharedData>>,
+    layer_manager: LayerManager,
     viewer_space: Space,
-    blend_mode: EnvironmentBlendMode,
+    shared_data: Arc<Mutex<Option<SharedData>>>,
     clip_planes: ClipPlanes,
-    view_configurations: Vec<openxr::ViewConfigurationView>,
-    secondary_configuration: Option<openxr::ViewConfigurationView>,
 
     // input
     action_set: ActionSet,
@@ -379,41 +369,196 @@ struct OpenXrDevice {
 }
 
 /// Data that is shared between the openxr thread and the
-/// surface provider that runs in the webgl thread.
+/// layer manager that runs in the webgl thread.
 struct SharedData {
     left: ViewInfo<LeftEye>,
     right: ViewInfo<RightEye>,
     secondary: Option<ViewInfo<Capture>>,
+    primary_blend_mode: EnvironmentBlendMode,
+    secondary_blend_mode: Option<EnvironmentBlendMode>,
     frame_state: Option<FrameState>,
-    frame_stream: FrameStream<D3D11>,
     space: Space,
 }
 
-struct OpenXrProvider {
-    images: Box<[<D3D11 as Graphics>::SwapchainImage]>,
-    image_queue: Vec<usize>,
-    surfaces: Box<[Option<Surface>]>,
-    swapchain: Swapchain<D3D11>,
-    shared_data: Arc<Mutex<SharedData>>,
-    fake_surface: Option<Surface>,
-    blend_mode: EnvironmentBlendMode,
-    secondary_blend_mode: Option<EnvironmentBlendMode>,
+struct OpenXrLayerManager {
+    session: Arc<Session<D3D11>>,
+    shared_data: Arc<Mutex<Option<SharedData>>>,
+    frame_stream: FrameStream<D3D11>,
+    layers: Vec<(ContextId, LayerId)>,
+    openxr_layers: HashMap<LayerId, OpenXrLayer>,
 }
 
-// This is required due to the presence of the swapchain image
-// pointers in the struct. D3D11 resources like textures are
-// safe to send between threads.
-unsafe impl Send for OpenXrProvider {}
+struct OpenXrLayer {
+    swapchain: Swapchain<D3D11>,
+    size: Size2D<i32, Viewport>,
+    images: Vec<<D3D11 as Graphics>::SwapchainImage>,
+    surface_textures: Vec<Option<SurfaceTexture>>,
+    waited: bool,
+}
 
-impl SurfaceProvider<SurfmanDevice> for OpenXrProvider {
-    fn recycle_front_buffer(&mut self, _device: &mut surfman::Device) {
+impl OpenXrLayerManager {
+    fn new(
+        session: Arc<Session<D3D11>>,
+        shared_data: Arc<Mutex<Option<SharedData>>>,
+        frame_stream: FrameStream<D3D11>,
+    ) -> OpenXrLayerManager {
+        let layers = Vec::new();
+        let openxr_layers = HashMap::new();
+        OpenXrLayerManager {
+            session,
+            shared_data,
+            frame_stream,
+            layers,
+            openxr_layers,
+        }
+    }
+
+    fn create_session(
+        device: &SurfmanDevice,
+        instance: &Instance,
+        system: SystemId,
+    ) -> Result<(Session<D3D11>, FrameWaiter, FrameStream<D3D11>), Error> {
+        // Get the current surfman device and extract it's D3D device. This will ensure
+        // that the OpenXR runtime's texture will be shareable with surfman's surfaces.
+        let native_device = device.native_device();
+        let d3d_device = native_device.d3d11_device;
+
+        // FIXME: we should be using these graphics requirements to drive the actual
+        //        d3d device creation, rather than assuming the device that surfman
+        //        already created is appropriate. OpenXR returns a validation error
+        //        unless we call this method, so we call it and ignore the results
+        //        in the short term.
+        let _requirements = D3D11::requirements(&instance, system)
+            .map_err(|e| Error::BackendSpecific(format!("D3D11::requirements {:?}", e)))?;
+
+        unsafe {
+            instance
+                .create_session::<D3D11>(system, &SessionCreateInfo { device: d3d_device })
+                .map_err(|e| Error::BackendSpecific(format!("Instance::create_session {:?}", e)))
+        }
+    }
+}
+
+impl OpenXrLayer {
+    fn new(swapchain: Swapchain<D3D11>, size: Size2D<i32, Viewport>) -> Result<OpenXrLayer, Error> {
+        let images = swapchain
+            .enumerate_images()
+            .map_err(|e| Error::BackendSpecific(format!("Session::enumerate_images {:?}", e)))?;
+        let waited = false;
+        let mut surface_textures = Vec::new();
+        surface_textures.resize_with(images.len(), || None);
+        Ok(OpenXrLayer {
+            swapchain,
+            size,
+            images,
+            surface_textures,
+            waited,
+        })
+    }
+
+    fn get_surface_texture(
+        &mut self,
+        device: &mut SurfmanDevice,
+        context: &mut SurfmanContext,
+        index: usize,
+    ) -> Result<&SurfaceTexture, SurfmanError> {
+        let result = self
+            .surface_textures
+            .get_mut(index)
+            .ok_or(SurfmanError::Failed)?;
+        if let Some(result) = result {
+            return Ok(result);
+        }
+        unsafe {
+            let image = ComPtr::from_raw(self.images[index]);
+            image.AddRef();
+            let surface_texture = device.create_surface_texture_from_texture(
+                context,
+                &self.size.to_untyped(),
+                image,
+            )?;
+            *result = Some(surface_texture);
+        }
+        result.as_ref().ok_or(SurfmanError::Failed)
+    }
+}
+
+impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
+    fn create_layer(
+        &mut self,
+        _device: &mut SurfmanDevice,
+        _context: &mut SurfmanContext,
+        context_id: ContextId,
+        init: LayerInit,
+    ) -> Result<LayerId, Error> {
+        let guard = self.shared_data.lock().unwrap();
+        let data = guard.as_ref().unwrap();
+
+        // XXXManishearth should we be doing this, or letting Servo set the format?
+        let formats = self.session.enumerate_swapchain_formats().map_err(|e| {
+            Error::BackendSpecific(format!("Session::enumerate_swapchain_formats {:?}", e))
+        })?;
+        let format = pick_format(&formats);
+        let texture_size = init.texture_size(&data.viewports());
+        let swapchain_create_info = SwapchainCreateInfo {
+            create_flags: SwapchainCreateFlags::EMPTY,
+            usage_flags: SwapchainUsageFlags::COLOR_ATTACHMENT | SwapchainUsageFlags::SAMPLED,
+            width: texture_size.width as u32,
+            height: texture_size.height as u32,
+            format,
+            sample_count: 1,
+            face_count: 1,
+            array_size: 1,
+            mip_count: 1,
+        };
+        let swapchain = self
+            .session
+            .create_swapchain(&swapchain_create_info)
+            .map_err(|e| Error::BackendSpecific(format!("Session::create_swapchain {:?}", e)))?;
+
+        let layer_id = LayerId::new();
+        let openxr_layer = OpenXrLayer::new(swapchain, texture_size)?;
+        self.layers.push((context_id, layer_id));
+        self.openxr_layers.insert(layer_id, openxr_layer);
+        Ok(layer_id)
+    }
+
+    fn destroy_layer(
+        &mut self,
+        _device: &mut SurfmanDevice,
+        _context: &mut SurfmanContext,
+        context_id: ContextId,
+        layer_id: LayerId,
+    ) {
+        self.layers.retain(|&ids| ids != (context_id, layer_id));
+        self.openxr_layers.remove(&layer_id);
+    }
+
+    fn layers(&self) -> &[(ContextId, LayerId)] {
+        &self.layers[..]
+    }
+
+    fn end_frame(
+        &mut self,
+        _device: &mut SurfmanDevice,
+        _contexts: &mut dyn GLContexts<SurfmanGL>,
+        layers: &[(ContextId, LayerId)],
+    ) -> Result<(), Error> {
+        let guard = self.shared_data.lock().unwrap();
+        let data = guard.as_ref().unwrap();
+
         // At this point the frame contents have been rendered, so we can release access to the texture
         // in preparation for displaying it.
-        let mut data = self.shared_data.lock().unwrap();
-        let data = &mut *data;
-        if let Err(e) = self.swapchain.release_image() {
-            error!("Error releasing swapchain image: {:?}", e);
+        for (_, openxr_layer) in &mut self.openxr_layers {
+            if openxr_layer.waited {
+                openxr_layer.swapchain.release_image().map_err(|e| {
+                    Error::BackendSpecific(format!("Session::release_image {:?}", e))
+                })?;
+                openxr_layer.waited = false;
+            }
         }
+
+        let openxr_layers = &self.openxr_layers;
 
         // Invert the up/down angles so that openxr flips the texture in the y axis.
         let mut l_fov = data.left.view.fov;
@@ -421,208 +566,206 @@ impl SurfaceProvider<SurfmanDevice> for OpenXrProvider {
         std::mem::swap(&mut l_fov.angle_up, &mut l_fov.angle_down);
         std::mem::swap(&mut r_fov.angle_up, &mut r_fov.angle_down);
 
-        let views = [
-            openxr::CompositionLayerProjectionView::new()
-                .pose(data.left.view.pose)
-                .fov(l_fov)
-                .sub_image(
-                    openxr::SwapchainSubImage::new()
-                        .swapchain(&self.swapchain)
-                        .image_array_index(0)
-                        .image_rect(openxr::Rect2Di {
-                            offset: openxr::Offset2Di { x: 0, y: 0 },
-                            extent: data.left.extent,
-                        }),
-                ),
-            openxr::CompositionLayerProjectionView::new()
-                .pose(data.right.view.pose)
-                .fov(r_fov)
-                .sub_image(
-                    openxr::SwapchainSubImage::new()
-                        .swapchain(&self.swapchain)
-                        .image_array_index(0)
-                        .image_rect(openxr::Rect2Di {
-                            offset: openxr::Offset2Di {
-                                x: data.left.extent.width,
-                                y: 0,
-                            },
-                            extent: data.right.extent,
-                        }),
-                ),
-        ];
+        let primary_views = layers
+            .iter()
+            .filter_map(|&(_, layer_id)| {
+                let openxr_layer = openxr_layers.get(&layer_id)?;
+                Some([
+                    openxr::CompositionLayerProjectionView::new()
+                        .pose(data.left.view.pose)
+                        .fov(l_fov)
+                        .sub_image(
+                            openxr::SwapchainSubImage::new()
+                                .swapchain(&openxr_layer.swapchain)
+                                .image_array_index(0)
+                                .image_rect(openxr::Rect2Di {
+                                    offset: openxr::Offset2Di { x: 0, y: 0 },
+                                    extent: data.left.extent,
+                                }),
+                        ),
+                    openxr::CompositionLayerProjectionView::new()
+                        .pose(data.right.view.pose)
+                        .fov(r_fov)
+                        .sub_image(
+                            openxr::SwapchainSubImage::new()
+                                .swapchain(&openxr_layer.swapchain)
+                                .image_array_index(0)
+                                .image_rect(openxr::Rect2Di {
+                                    offset: openxr::Offset2Di {
+                                        x: data.left.extent.width,
+                                        y: 0,
+                                    },
+                                    extent: data.right.extent,
+                                }),
+                        ),
+                ])
+            })
+            .collect::<Vec<_>>();
 
-        let layers = [&*CompositionLayerProjection::new()
-            .space(&data.space)
-            .layer_flags(CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA)
-            .views(&views[..])];
+        let primary_layers = primary_views
+            .iter()
+            .map(|views| {
+                CompositionLayerProjection::new()
+                    .space(&data.space)
+                    .layer_flags(CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA)
+                    .views(&views[..])
+            })
+            .collect::<Vec<_>>();
+
+        let primary_layers = primary_layers
+            .iter()
+            .map(|layer| layer.deref())
+            .collect::<Vec<_>>();
 
         if let Some(ref secondary) = data.secondary {
             let mut s_fov = secondary.view.fov;
-            let secondary_blend_mode = self
-                .secondary_blend_mode
-                .expect("secondary blend mode must be set if secondary views are enabled");
             std::mem::swap(&mut s_fov.angle_up, &mut s_fov.angle_down);
-            let views = [openxr::CompositionLayerProjectionView::new()
-                .pose(secondary.view.pose)
-                .fov(s_fov)
-                .sub_image(
-                    openxr::SwapchainSubImage::new()
-                        .swapchain(&self.swapchain)
-                        .image_array_index(0)
-                        .image_rect(openxr::Rect2Di {
-                            offset: openxr::Offset2Di {
-                                x: data.left.extent.width + data.right.extent.width,
-                                y: 0,
-                            },
-                            extent: secondary.extent,
-                        }),
-                )];
+            let secondary_views = layers
+                .iter()
+                .filter_map(|&(_, layer_id)| {
+                    let openxr_layer = openxr_layers.get(&layer_id)?;
+                    Some([openxr::CompositionLayerProjectionView::new()
+                        .pose(secondary.view.pose)
+                        .fov(s_fov)
+                        .sub_image(
+                            openxr::SwapchainSubImage::new()
+                                .swapchain(&openxr_layer.swapchain)
+                                .image_array_index(0)
+                                .image_rect(openxr::Rect2Di {
+                                    offset: openxr::Offset2Di {
+                                        x: data.left.extent.width + data.right.extent.width,
+                                        y: 0,
+                                    },
+                                    extent: secondary.extent,
+                                }),
+                        )])
+                })
+                .collect::<Vec<_>>();
 
-            let secondary_layers = [&*CompositionLayerProjection::new()
-                .space(&data.space)
-                .layer_flags(CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA)
-                .views(&views[..])];
-            if let Err(e) = data.frame_stream.end_secondary(
-                data.frame_state.as_ref().unwrap().predicted_display_time,
-                self.blend_mode,
-                &layers[..],
-                SecondaryEndInfo {
-                    ty: ViewConfigurationType::SECONDARY_MONO_FIRST_PERSON_OBSERVER_MSFT,
-                    // XXXManishearth should we use the secondary layer's blend mode here, given
-                    // that the content will be using the primary blend mode?
-                    environment_blend_mode: secondary_blend_mode,
-                    layers: &secondary_layers,
-                },
-            ) {
-                error!("Error ending frame: {:?}", e);
-            }
-        } else {
-            if let Err(e) = data.frame_stream.end(
-                data.frame_state.as_ref().unwrap().predicted_display_time,
-                self.blend_mode,
-                &layers[..],
-            ) {
-                error!("Error ending frame: {:?}", e);
-            }
-        }
-    }
+            let secondary_layers = secondary_views
+                .iter()
+                .map(|views| {
+                    CompositionLayerProjection::new()
+                        .space(&data.space)
+                        .layer_flags(CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA)
+                        .views(&views[..])
+                })
+                .collect::<Vec<_>>();
 
-    fn recycle_surface(&mut self, surface: Surface) {
-        assert!(self.fake_surface.is_none());
-        self.fake_surface = Some(surface);
-    }
+            let secondary_layers = secondary_layers
+                .iter()
+                .map(|layer| layer.deref())
+                .collect::<Vec<_>>();
 
-    fn provide_surface(
-        &mut self,
-        device: &mut surfman::Device,
-        context: &mut surfman::Context,
-        size: euclid::default::Size2D<i32>,
-    ) -> Result<Surface, surfman::Error> {
-        let image = self.swapchain.acquire_image().map_err(|e| {
-            error!("Error acquiring swapchain image: {:?}", e);
-            surfman::Error::Failed
-        })?;
-        self.swapchain
-            .wait_image(openxr::Duration::INFINITE)
-            .map_err(|e| {
-                error!("Error waiting on swapchain image: {:?}", e);
-                surfman::Error::Failed
-            })?;
-
-        // Store the current image index that was acquired in the queue of
-        // surfaces that have been handed out.
-        self.image_queue.push(image as usize);
-
-        // If we already have a surface, we can return it immediately.
-        // Otherwise we need to create a new surface that wraps the
-        // OpenXR texture.
-        let surface = self.surfaces[image as usize]
-            .take()
-            .ok_or(surfman::Error::SurfaceDataInaccessible)
-            .or_else(|_| unsafe {
-                device.create_surface_from_texture(
-                    context,
-                    &Size2D::new(size.width, size.height),
-                    self.images[image as usize],
+            self.frame_stream
+                .end_secondary(
+                    data.frame_state.as_ref().unwrap().predicted_display_time,
+                    data.primary_blend_mode,
+                    &primary_layers[..],
+                    SecondaryEndInfo {
+                        ty: ViewConfigurationType::SECONDARY_MONO_FIRST_PERSON_OBSERVER_MSFT,
+                        // XXXManishearth should we use the secondary layer's blend mode here, given
+                        // that the content will be using the primary blend mode?
+                        environment_blend_mode: data
+                            .secondary_blend_mode
+                            .unwrap_or(data.primary_blend_mode),
+                        layers: &secondary_layers[..],
+                    },
                 )
-            });
-        surface
-    }
-
-    fn take_front_buffer(&mut self) -> Option<Surface> {
-        self.fake_surface.take()
-    }
-
-    fn set_front_buffer(
-        &mut self,
-        device: &mut surfman::Device,
-        context: &mut surfman::Context,
-        new_front_buffer: Surface,
-    ) -> Result<(), surfman::Error> {
-        // At this point the front buffer's contents are already present in the underlying openxr texture.
-        // We only need to store the surface because the webxr crate's API assumes that Surface objects
-        // must be passed to the rendering method.
-
-        // Return the complete surface to the surface cache in the position corresponding
-        // to the front of the outstanding surface queue.
-        let pending_idx = self.image_queue[0];
-        assert!(self.surfaces[pending_idx].is_none());
-        self.surfaces[pending_idx] = Some(new_front_buffer);
-        // Remove the first element of the queue of outstanding surfaces.
-        self.image_queue.remove(0);
-
-        // We will be handing out a threadsafe surface in the future, so we need
-        // to create it if it doesn't already exist.
-        if self.fake_surface.is_none() {
-            self.fake_surface = Some(device.create_surface(
-                context,
-                surfman::SurfaceAccess::GPUOnly,
-                surfman::SurfaceType::Generic {
-                    size: Size2D::new(1, 1),
-                },
-            )?);
-        }
-
-        Ok(())
-    }
-
-    fn create_sized_surface(
-        &mut self,
-        _device: &mut surfman::Device,
-        _context: &mut surfman::Context,
-        _size: euclid::default::Size2D<i32>,
-    ) -> Result<Surface, surfman::Error> {
-        // All OpenXR-based surfaces are created once during session initialization; we cannot create new ones.
-        // This is only used when resizing, however, and OpenXR-based systems don't resize.
-        Err(surfman::Error::UnsupportedOnThisPlatform)
-    }
-
-    fn destroy_all_surfaces(
-        &mut self,
-        device: &mut surfman::Device,
-        context: &mut surfman::Context,
-    ) -> Result<(), surfman::Error> {
-        // Destroy any cached surfaces that wrap OpenXR textures.
-        for surface in self.surfaces.iter_mut().map(Option::take) {
-            if let Some(mut surface) = surface {
-                device.destroy_surface(context, &mut surface)?;
-            }
-        }
-        if let Some(mut fake) = self.fake_surface.take() {
-            device.destroy_surface(context, &mut fake)?;
+                .map_err(|e| {
+                    Error::BackendSpecific(format!("FrameStream::end_secondary {:?}", e))
+                })?;
+        } else {
+            self.frame_stream
+                .end(
+                    data.frame_state.as_ref().unwrap().predicted_display_time,
+                    data.primary_blend_mode,
+                    &primary_layers[..],
+                )
+                .map_err(|e| Error::BackendSpecific(format!("FrameStream::end {:?}", e)))?;
         }
         Ok(())
+    }
+
+    fn begin_frame(
+        &mut self,
+        device: &mut SurfmanDevice,
+        contexts: &mut dyn GLContexts<SurfmanGL>,
+        layers: &[(ContextId, LayerId)],
+    ) -> Result<Vec<SubImages>, Error> {
+        self.frame_stream
+            .begin()
+            .map_err(|e| Error::BackendSpecific(format!("FrameStream::begin {:?}", e)))?;
+        layers
+            .iter()
+            .map(|&(context_id, layer_id)| {
+                let context = contexts
+                    .context(device, context_id)
+                    .ok_or(Error::NoMatchingDevice)?;
+                let openxr_layer = self
+                    .openxr_layers
+                    .get_mut(&layer_id)
+                    .ok_or(Error::NoMatchingDevice)?;
+
+                let image = openxr_layer.swapchain.acquire_image().map_err(|e| {
+                    Error::BackendSpecific(format!("Swapchain::acquire_image {:?}", e))
+                })?;
+                openxr_layer
+                    .swapchain
+                    .wait_image(openxr::Duration::INFINITE)
+                    .map_err(|e| {
+                        Error::BackendSpecific(format!("Swapchain::wait_image {:?}", e))
+                    })?;
+                openxr_layer.waited = true;
+
+                let color_surface_texture = openxr_layer
+                    .get_surface_texture(device, context, image as usize)
+                    .map_err(|e| {
+                        Error::BackendSpecific(format!("Layer::get_surface_texture {:?}", e))
+                    })?;
+                let color_texture = device.surface_texture_object(color_surface_texture);
+                let depth_stencil_texture = None;
+                let texture_array_index = None;
+                let origin = Point2D::new(0, 0);
+                let texture_size = openxr_layer.size;
+                let offset = Point2D::new(texture_size.width / 2, 0);
+                let view_size = Size2D::new(texture_size.width / 2, texture_size.height);
+                let sub_image = Some(SubImage {
+                    color_texture,
+                    depth_stencil_texture,
+                    texture_array_index,
+                    viewport: Rect::new(origin, texture_size),
+                });
+                let view_sub_images = vec![
+                    SubImage {
+                        color_texture,
+                        depth_stencil_texture,
+                        texture_array_index,
+                        viewport: Rect::new(origin, view_size),
+                    },
+                    SubImage {
+                        color_texture,
+                        depth_stencil_texture,
+                        texture_array_index,
+                        viewport: Rect::new(offset, view_size),
+                    },
+                ];
+                Ok(SubImages {
+                    layer_id,
+                    sub_image,
+                    view_sub_images,
+                })
+            })
+            .collect()
     }
 }
 
 impl OpenXrDevice {
     fn new(
-        gl_thread: Box<dyn GlThread>,
-        provider_registration: Box<dyn SurfaceProviderRegistration>,
         instance: CreatedInstance,
         granted_features: Vec<String>,
-        id: SessionId,
         context_menu_provider: Box<dyn ContextMenuProvider>,
+        grand_manager: LayerGrandManager<SurfmanGL>,
     ) -> Result<OpenXrDevice, Error> {
         let CreatedInstance {
             instance,
@@ -631,39 +774,28 @@ impl OpenXrDevice {
             system,
         } = instance;
 
-        let (device_tx, device_rx) = crossbeam_channel::unbounded();
-        let (provider_tx, provider_rx) = crossbeam_channel::unbounded();
-        let _ = gl_thread.execute(Box::new(move |device| {
-            // Get the current surfman device and extract it's D3D device. This will ensure
-            // that the OpenXR runtime's texture will be shareable with surfman's surfaces.
-            let native_device = device.native_device();
-            let d3d_device = native_device.d3d11_device;
-            // Smuggle the pointer out as a usize value; D3D11 devices are threadsafe
-            // so it's safe to use it from another thread.
-            let _ = device_tx.send(d3d_device as usize);
-            let _ = provider_rx.recv();
-        }));
-        // Get the D3D11 device pointer from the webgl thread.
-        let device = device_rx.recv().unwrap();
+        let (init_tx, init_rx) = crossbeam_channel::unbounded();
 
-        // OpenXR returns a validation error unless we call this method, so we call it
-        // and ignore the results. Users of this backend are expected to have already called
-        // create_surfman_adapter, which uses the graphics requirements to create a matching
-        // surfman adapter. The previous code that obtains a D3D11 device is expected to
-        // have been created via this matching adapter.
-        let _requirements = D3D11::requirements(&instance, system)
-            .map_err(|e| Error::BackendSpecific(format!("D3D11::requirements {:?}", e)))?;
+        let instance_clone = instance.clone();
+        let shared_data = Arc::new(Mutex::new(None));
+        let shared_data_clone = shared_data.clone();
+        let mut data = shared_data.lock().unwrap();
 
-        let (session, frame_waiter, frame_stream) = unsafe {
-            instance
-                .create_session::<D3D11>(
-                    system,
-                    &SessionCreateInfo {
-                        device: device as *mut _,
-                    },
-                )
-                .map_err(|e| Error::BackendSpecific(format!("Instance::create_session {:?}", e)))?
-        };
+        let layer_manager = grand_manager.create_layer_manager(move |device, _| {
+            let (session, frame_waiter, frame_stream) =
+                OpenXrLayerManager::create_session(device, &instance_clone, system)?;
+            let session = Arc::new(session);
+            init_tx
+                .send((session.clone(), frame_waiter))
+                .map_err(|_| Error::CommunicationError)?;
+            Ok(OpenXrLayerManager::new(
+                session,
+                shared_data_clone,
+                frame_stream,
+            ))
+        })?;
+
+        let (session, frame_waiter) = init_rx.recv().map_err(|_| Error::CommunicationError)?;
 
         // XXXPaul initialisation should happen on SessionStateChanged(Ready)?
 
@@ -717,15 +849,6 @@ impl OpenXrDevice {
                 ))
             })?;
 
-        let blend_mode = instance
-            .enumerate_environment_blend_modes(system, view_configuration_type)
-            .map_err(|e| {
-                Error::BackendSpecific(format!(
-                    "Instance::enumerate_environment_blend_modes {:?}",
-                    e
-                ))
-            })?[0];
-
         let left_view_configuration = view_configurations[0];
         let right_view_configuration = view_configurations[1];
         let left_extent = Extent2Di {
@@ -741,10 +864,8 @@ impl OpenXrDevice {
             left_view_configuration.recommended_image_rect_height,
             right_view_configuration.recommended_image_rect_height,
         );
-        let mut sw_width = left_view_configuration.recommended_image_rect_width
-            + right_view_configuration.recommended_image_rect_width;
-        let mut sw_height = left_view_configuration.recommended_image_rect_height;
-        let (secondary_configuration, secondary_blend_mode) = if supports_secondary {
+
+        let (secondary, secondary_blend_mode) = if supports_secondary {
             let view_configuration = *instance
                 .enumerate_view_configuration_views(
                     system,
@@ -761,11 +882,6 @@ impl OpenXrDevice {
                     "Session::enumerate_view_configuration_views() returned no secondary views",
                 );
 
-            sw_width += view_configuration.recommended_image_rect_width / SECONDARY_VIEW_DOWNSCALE;
-            sw_height = cmp::max(
-                sw_height,
-                view_configuration.recommended_image_rect_height / SECONDARY_VIEW_DOWNSCALE,
-            );
             let secondary_blend_mode = instance
                 .enumerate_environment_blend_modes(
                     system,
@@ -777,42 +893,33 @@ impl OpenXrDevice {
                         e
                     ))
                 })?[0];
-            (Some(view_configuration), Some(secondary_blend_mode))
+
+            let secondary_extent = Extent2Di {
+                width: (view_configuration.recommended_image_rect_width / SECONDARY_VIEW_DOWNSCALE)
+                    as i32,
+                height: (view_configuration.recommended_image_rect_height
+                    / SECONDARY_VIEW_DOWNSCALE) as i32,
+            };
+
+            let secondary = ViewInfo {
+                view: VIEW_INIT,
+                extent: secondary_extent,
+                cached_projection: Transform3D::identity(),
+            };
+
+            (Some(secondary), Some(secondary_blend_mode))
         } else {
             (None, None)
         };
 
-        // Create swapchains
-
-        // XXXManishearth should we be doing this, or letting Servo set the format?
-        let formats = session.enumerate_swapchain_formats().map_err(|e| {
-            Error::BackendSpecific(format!("Session::enumerate_swapchain_formats {:?}", e))
-        })?;
-        let format = pick_format(&formats);
-
-        let swapchain_create_info = SwapchainCreateInfo {
-            create_flags: SwapchainCreateFlags::EMPTY,
-            usage_flags: SwapchainUsageFlags::COLOR_ATTACHMENT | SwapchainUsageFlags::SAMPLED,
-            format,
-            sample_count: 1,
-            width: sw_width,
-            height: sw_height,
-            face_count: 1,
-            array_size: 1,
-            mip_count: 1,
-        };
-
-        let swapchain = session
-            .create_swapchain(&swapchain_create_info)
-            .map_err(|e| Error::BackendSpecific(format!("Session::create_swapchain {:?}", e)))?;
-        let images = swapchain
-            .enumerate_images()
-            .map_err(|e| Error::BackendSpecific(format!("Session::enumerate_images {:?}", e)))?;
-
-        let mut surfaces = Vec::with_capacity(images.len());
-        for _ in 0..images.len() {
-            surfaces.push(None);
-        }
+        let primary_blend_mode = instance
+            .enumerate_environment_blend_modes(system, view_configuration_type)
+            .map_err(|e| {
+                Error::BackendSpecific(format!(
+                    "Instance::enumerate_environment_blend_modes {:?}",
+                    e
+                ))
+            })?[0];
 
         let left = ViewInfo {
             view: VIEW_INIT,
@@ -824,31 +931,16 @@ impl OpenXrDevice {
             extent: right_extent,
             cached_projection: Transform3D::identity(),
         };
-        let shared_data = Arc::new(Mutex::new(SharedData {
-            frame_stream,
+        *data = Some(SharedData {
             frame_state: None,
             space,
             left,
             right,
-            secondary: None,
-        }));
-
-        let provider = Box::new(OpenXrProvider {
-            swapchain,
-            image_queue: Vec::with_capacity(images.len()),
-            images: images.into_boxed_slice(),
-            surfaces: surfaces.into_boxed_slice(),
-            fake_surface: None,
-            shared_data: shared_data.clone(),
-            blend_mode,
+            secondary,
+            primary_blend_mode,
             secondary_blend_mode,
         });
-        provider_registration.register(id, provider);
-        // Ensure the webgl thread is blocked until we're done initializing
-        // the surface provider.
-        let _ = provider_tx.send(());
-
-        // input
+        drop(data);
 
         let (action_set, right_hand, left_hand) =
             OpenXRInput::setup_inputs(&instance, &session, supports_hands);
@@ -860,9 +952,7 @@ impl OpenXrDevice {
             frame_waiter,
             viewer_space,
             clip_planes: Default::default(),
-            blend_mode,
-            view_configurations,
-            secondary_configuration,
+            layer_manager,
             shared_data,
 
             action_set,
@@ -941,65 +1031,62 @@ impl OpenXrDevice {
     }
 }
 
-impl OpenXrDevice {
-    fn views(&self, data: &SharedData) -> Views {
-        let left_view = data.left.view();
-        let right_view = data.right.view();
-        if self.secondary_configuration.is_some() {
-            if let Some(ref secondary) = data.secondary {
-                let third_eye = secondary.view();
-                return Views::StereoCapture(left_view, right_view, third_eye);
-            }
+impl SharedData {
+    fn views(&self) -> Views {
+        let left_view = self.left.view();
+        let right_view = self.right.view();
+        if let Some(ref secondary) = self.secondary {
+            let third_eye = secondary.view();
+            return Views::StereoCapture(left_view, right_view, third_eye);
         }
         Views::Stereo(left_view, right_view)
     }
+
+    fn viewports(&self) -> Viewports {
+        let left_vp = Rect::new(
+            Point2D::zero(),
+            Size2D::new(self.left.extent.width, self.left.extent.height),
+        );
+        let right_vp = Rect::new(
+            Point2D::new(self.left.extent.width, 0),
+            Size2D::new(self.right.extent.width, self.right.extent.height),
+        );
+        let mut viewports = vec![left_vp, right_vp];
+        if let Some(ref secondary) = self.secondary {
+            let secondary_vp = Rect::new(
+                Point2D::new(self.left.extent.width + self.right.extent.width, 0),
+                Size2D::new(secondary.extent.width, secondary.extent.height),
+            );
+            viewports.push(secondary_vp)
+        }
+        Viewports { viewports }
+    }
 }
 
-impl DeviceAPI<Surface> for OpenXrDevice {
+impl DeviceAPI for OpenXrDevice {
     fn floor_transform(&self) -> Option<RigidTransform3D<f32, Native, Floor>> {
         let translation = Vector3D::new(0.0, HEIGHT, 0.0);
         Some(RigidTransform3D::from_translation(translation))
     }
 
     fn viewports(&self) -> Viewports {
-        let left_view_configuration = &self.view_configurations[0];
-        let right_view_configuration = &self.view_configurations[1];
-        let left_vp = Rect::new(
-            Point2D::zero(),
-            Size2D::new(
-                left_view_configuration.recommended_image_rect_width as i32,
-                left_view_configuration.recommended_image_rect_height as i32,
-            ),
-        );
-        let right_vp = Rect::new(
-            Point2D::new(
-                left_view_configuration.recommended_image_rect_width as i32,
-                0,
-            ),
-            Size2D::new(
-                right_view_configuration.recommended_image_rect_width as i32,
-                right_view_configuration.recommended_image_rect_height as i32,
-            ),
-        );
-        let mut viewports = vec![left_vp, right_vp];
-        if let Some(config) = self.secondary_configuration {
-            let secondary_vp = Rect::new(
-                Point2D::new(
-                    left_view_configuration.recommended_image_rect_width as i32
-                        + right_view_configuration.recommended_image_rect_width as i32,
-                    0,
-                ),
-                Size2D::new(
-                    (config.recommended_image_rect_width / SECONDARY_VIEW_DOWNSCALE) as i32,
-                    (config.recommended_image_rect_height / SECONDARY_VIEW_DOWNSCALE) as i32,
-                ),
-            );
-            viewports.push(secondary_vp)
-        }
-        Viewports { viewports }
+        self.shared_data
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .viewports()
     }
 
-    fn wait_for_animation_frame(&mut self) -> Option<Frame> {
+    fn create_layer(&mut self, context_id: ContextId, init: LayerInit) -> Result<LayerId, Error> {
+        self.layer_manager.create_layer(context_id, init)
+    }
+
+    fn destroy_layer(&mut self, context_id: ContextId, layer_id: LayerId) {
+        self.layer_manager.destroy_layer(context_id, layer_id)
+    }
+
+    fn begin_animation_frame(&mut self, layers: &[(ContextId, LayerId)]) -> Option<Frame> {
         if !self.handle_openxr_events() {
             warn!("no frame, session isn't running");
             // Session is not running anymore.
@@ -1016,64 +1103,17 @@ impl DeviceAPI<Surface> for OpenXrDevice {
             }
         }
 
-        let mut data = self.shared_data.lock().unwrap();
-        let frame_state = if let Some(secondary_configuration) = self.secondary_configuration {
-            let (frame_state, secondary_state) = match self
-                .frame_waiter
-                .wait_secondary(ViewConfigurationType::SECONDARY_MONO_FIRST_PERSON_OBSERVER_MSFT)
-            {
-                Ok(frame_state) => frame_state,
-                Err(e) => {
-                    error!("Error waiting on frame: {:?}", e);
-                    return None;
-                }
-            };
-
-            assert_eq!(
-                secondary_state.ty,
-                ViewConfigurationType::SECONDARY_MONO_FIRST_PERSON_OBSERVER_MSFT
-            );
-
-            if data.secondary.is_some() != secondary_state.active {
-                let extent = Extent2Di {
-                    width: (secondary_configuration.recommended_image_rect_width
-                        / SECONDARY_VIEW_DOWNSCALE) as i32,
-                    height: (secondary_configuration.recommended_image_rect_height
-                        / SECONDARY_VIEW_DOWNSCALE) as i32,
-                };
-                data.secondary = if secondary_state.active {
-                    Some(ViewInfo {
-                        view: VIEW_INIT,
-                        extent,
-                        cached_projection: Transform3D::identity(),
-                    })
-                } else {
-                    None
-                };
-
-                println!(
-                    "Secondary view configuration state changed to {}",
-                    secondary_state.active
-                );
-            }
-
-            frame_state
-        } else {
-            match self.frame_waiter.wait() {
-                Ok(frame_state) => frame_state,
-                Err(e) => {
-                    error!("Error waiting on frame: {:?}", e);
-                    return None;
-                }
+        let mut guard = self.shared_data.lock().unwrap();
+        let mut data = guard.as_mut().unwrap();
+        let frame_state = match self.frame_waiter.wait() {
+            Ok(frame_state) => frame_state,
+            Err(e) => {
+                error!("Error waiting on frame: {:?}", e);
+                return None;
             }
         };
 
         let time_ns = time::precise_time_ns();
-
-        if let Err(e) = data.frame_stream.begin() {
-            error!("Error beginning frame stream: {:?}", e);
-            return None;
-        }
 
         // XXXManishearth should we check frame_state.should_render?
         let (_view_flags, views) = match self.session.locate_views(
@@ -1133,7 +1173,9 @@ impl DeviceAPI<Surface> for OpenXrDevice {
             .frame(&self.session, &frame_state, &data.space, &transform);
 
         data.frame_state = Some(frame_state);
-        let views = self.views(&data);
+        let views = data.views();
+
+        let sub_images = self.layer_manager.begin_frame(layers).ok()?;
 
         if (left.menu_selected || right.menu_selected) && self.context_menu_future.is_none() {
             self.context_menu_future = Some(self.context_menu_provider.open_context_menu());
@@ -1156,6 +1198,7 @@ impl DeviceAPI<Surface> for OpenXrDevice {
             inputs: vec![right.frame, left.frame],
             events: vec![],
             time_ns,
+            sub_images,
             sent_time: 0,
             hit_test_results: vec![],
         };
@@ -1195,11 +1238,12 @@ impl DeviceAPI<Surface> for OpenXrDevice {
         Some(frame)
     }
 
-    fn render_animation_frame(&mut self, surface: Surface) -> Surface {
-        // We have already told OpenXR to display the frame as part of `recycle_front_buffer`.
+    fn end_animation_frame(&mut self, layers: &[(ContextId, LayerId)]) {
+        // We tell OpenXR to display the frame in the layer manager.
         // Due to threading issues we can't call D3D11 APIs on the openxr thread as the
-        // WebGL thread might be using the device simultaneously, so this method is a no-op.
-        surface
+        // WebGL thread might be using the device simultaneously, so this method delegates
+        // everything to the layer manager.
+        let _ = self.layer_manager.end_frame(layers);
     }
 
     fn initial_inputs(&self) -> Vec<InputSource> {
@@ -1255,7 +1299,14 @@ impl DeviceAPI<Surface> for OpenXrDevice {
     }
 
     fn environment_blend_mode(&self) -> webxr_api::EnvironmentBlendMode {
-        match self.blend_mode {
+        match self
+            .shared_data
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .primary_blend_mode
+        {
             EnvironmentBlendMode::OPAQUE => webxr_api::EnvironmentBlendMode::Opaque,
             EnvironmentBlendMode::ALPHA_BLEND => webxr_api::EnvironmentBlendMode::AlphaBlend,
             EnvironmentBlendMode::ADDITIVE => webxr_api::EnvironmentBlendMode::Additive,

--- a/webxr/surfman_layer_manager.rs
+++ b/webxr/surfman_layer_manager.rs
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! An implementation of layer management using surfman
+
+use euclid::Point2D;
+use euclid::Rect;
+use euclid::Size2D;
+
+use sparkle::gl::Gl;
+
+use std::collections::HashMap;
+
+use surfman::Context as SurfmanContext;
+use surfman::Device as SurfmanDevice;
+use surfman::SurfaceAccess;
+use surfman::SurfaceTexture;
+
+use surfman_chains::SwapChains;
+use surfman_chains::SwapChainsAPI;
+
+use webxr_api::ContextId;
+use webxr_api::Error;
+use webxr_api::GLContexts;
+use webxr_api::GLTypes;
+use webxr_api::LayerId;
+use webxr_api::LayerInit;
+use webxr_api::LayerManagerAPI;
+use webxr_api::SubImage;
+use webxr_api::SubImages;
+use webxr_api::Viewports;
+
+#[derive(Copy, Clone, Debug)]
+pub enum SurfmanGL {}
+
+impl GLTypes for SurfmanGL {
+    type Device = SurfmanDevice;
+    type Context = SurfmanContext;
+    type Bindings = Gl;
+}
+
+pub struct SurfmanLayerManager {
+    layers: Vec<(ContextId, LayerId)>,
+    swap_chains: SwapChains<LayerId, SurfmanDevice>,
+    textures: HashMap<LayerId, SurfaceTexture>,
+    viewports: Viewports,
+}
+
+impl SurfmanLayerManager {
+    pub fn new(
+        viewports: Viewports,
+        swap_chains: SwapChains<LayerId, SurfmanDevice>,
+    ) -> SurfmanLayerManager {
+        let layers = Vec::new();
+        let textures = HashMap::new();
+        SurfmanLayerManager {
+            layers,
+            swap_chains,
+            textures,
+            viewports,
+        }
+    }
+}
+
+impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
+    fn create_layer(
+        &mut self,
+        device: &mut SurfmanDevice,
+        context: &mut SurfmanContext,
+        context_id: ContextId,
+        init: LayerInit,
+    ) -> Result<LayerId, Error> {
+        let texture_size = init.texture_size(&self.viewports);
+        let layer_id = LayerId::new();
+        let access = SurfaceAccess::GPUOnly;
+        let size = texture_size.to_untyped();
+        self.swap_chains
+            .create_detached_swap_chain(layer_id, size, device, context, access)
+            .map_err(|err| Error::BackendSpecific(format!("{:?}", err)))?;
+        self.layers.push((context_id, layer_id));
+        Ok(layer_id)
+    }
+
+    fn destroy_layer(
+        &mut self,
+        device: &mut SurfmanDevice,
+        context: &mut SurfmanContext,
+        context_id: ContextId,
+        layer_id: LayerId,
+    ) {
+        self.layers.retain(|&ids| ids != (context_id, layer_id));
+        let _ = self.swap_chains.destroy(layer_id, device, context);
+        self.textures.remove(&layer_id);
+    }
+
+    fn layers(&self) -> &[(ContextId, LayerId)] {
+        &self.layers[..]
+    }
+
+    fn begin_frame(
+        &mut self,
+        device: &mut SurfmanDevice,
+        contexts: &mut dyn GLContexts<SurfmanGL>,
+        layers: &[(ContextId, LayerId)],
+    ) -> Result<Vec<SubImages>, Error> {
+        layers
+            .iter()
+            .map(|&(context_id, layer_id)| {
+                let context = contexts
+                    .context(device, context_id)
+                    .ok_or(Error::NoMatchingDevice)?;
+                let swap_chain = self
+                    .swap_chains
+                    .get(layer_id)
+                    .ok_or(Error::NoMatchingDevice)?;
+                let surface_size = Size2D::from_untyped(swap_chain.size());
+                let surface_texture = swap_chain
+                    .take_surface_texture(device, context)
+                    .map_err(|_| Error::NoMatchingDevice)?;
+                let color_texture = device.surface_texture_object(&surface_texture);
+                let depth_stencil_texture = None;
+                let texture_array_index = None;
+                let origin = Point2D::new(0, 0);
+                let offset = Point2D::new(surface_size.width / 2, 0);
+                let view_size = Size2D::new(surface_size.width / 2, surface_size.height);
+                let sub_image = Some(SubImage {
+                    color_texture,
+                    depth_stencil_texture,
+                    texture_array_index,
+                    viewport: Rect::new(origin, surface_size),
+                });
+                let view_sub_images = vec![
+                    SubImage {
+                        color_texture,
+                        depth_stencil_texture,
+                        texture_array_index,
+                        viewport: Rect::new(origin, view_size),
+                    },
+                    SubImage {
+                        color_texture,
+                        depth_stencil_texture,
+                        texture_array_index,
+                        viewport: Rect::new(offset, view_size),
+                    },
+                ];
+                self.textures.insert(layer_id, surface_texture);
+                Ok(SubImages {
+                    layer_id,
+                    sub_image,
+                    view_sub_images,
+                })
+            })
+            .collect()
+    }
+
+    fn end_frame(
+        &mut self,
+        device: &mut SurfmanDevice,
+        contexts: &mut dyn GLContexts<SurfmanGL>,
+        layers: &[(ContextId, LayerId)],
+    ) -> Result<(), Error> {
+        for &(context_id, layer_id) in layers {
+            let gl = contexts
+                .bindings(device, context_id)
+                .ok_or(Error::NoMatchingDevice)?;
+            gl.flush();
+            let context = contexts
+                .context(device, context_id)
+                .ok_or(Error::NoMatchingDevice)?;
+            let surface_texture = self
+                .textures
+                .remove(&layer_id)
+                .ok_or(Error::NoMatchingDevice)?;
+            let swap_chain = self
+                .swap_chains
+                .get(layer_id)
+                .ok_or(Error::NoMatchingDevice)?;
+            swap_chain
+                .recycle_surface_texture(device, context, surface_texture)
+                .map_err(|err| Error::BackendSpecific(format!("{:?}", err)))?;
+            swap_chain
+                .swap_buffers(device, context)
+                .map_err(|err| Error::BackendSpecific(format!("{:?}", err)))?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds layer management to webxr. There's an API for creating and destroying layers, and for specifying which layers to use in a frame. This removes all of the special-cased code for openxr, since the layer manager can be run in the webgl thread.