### PR TITLE
Support depth and stencil in surfman layer manager

### DIFF
--- a/webxr-api/layer.rs
+++ b/webxr-api/layer.rs
@@ -90,7 +90,7 @@ pub trait LayerManagerAPI<GL: GLTypes> {
     fn create_layer(
         &mut self,
         device: &mut GL::Device,
-        context: &mut GL::Context,
+        contexts: &mut dyn GLContexts<GL>,
         context_id: ContextId,
         init: LayerInit,
     ) -> Result<LayerId, Error>;
@@ -98,7 +98,7 @@ pub trait LayerManagerAPI<GL: GLTypes> {
     fn destroy_layer(
         &mut self,
         device: &mut GL::Device,
-        context: &mut GL::Context,
+        contexts: &mut dyn GLContexts<GL>,
         context_id: ContextId,
         layer_id: LayerId,
     );

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -492,7 +492,7 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
     fn create_layer(
         &mut self,
         _device: &mut SurfmanDevice,
-        _context: &mut SurfmanContext,
+        _contexts: &mut dyn GLContexts<SurfmanGL>,
         context_id: ContextId,
         init: LayerInit,
     ) -> Result<LayerId, Error> {
@@ -531,7 +531,7 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
     fn destroy_layer(
         &mut self,
         _device: &mut SurfmanDevice,
-        _context: &mut SurfmanContext,
+        _contexts: &mut dyn GLContexts<SurfmanGL>,
         context_id: ContextId,
         layer_id: LayerId,
     ) {


### PR DESCRIPTION
Creating a depth/stencil attachment requires access to the GL bindings when creating/destroying a layer, so the layer managemnt API has to change slightly.