### PR TITLE
Allow support for secondary views to be toggled by a pref

### DIFF
--- a/webxr-api/session.rs
+++ b/webxr-api/session.rs
@@ -52,6 +52,10 @@ pub enum SessionMode {
 pub struct SessionInit {
     pub required_features: Vec<String>,
     pub optional_features: Vec<String>,
+    /// Secondary views are enabled with the `secondary-view` feature
+    /// but for performance reasons we also ask users to enable this pref
+    /// for now.
+    pub first_person_observer_view: bool,
 }
 
 impl SessionInit {


### PR DESCRIPTION
Implements https://github.com/immersive-web/webxr/pull/1083 , and moves the constant to a pref to be toggled by the user.

For now I'd like to keep it a pref since there are perf implications of always enabling this.