### PR TITLE
Enable alpha blending in the glwindow device

### DIFF
--- a/webxr/glwindow/mod.rs
+++ b/webxr/glwindow/mod.rs
@@ -276,7 +276,7 @@ impl DeviceAPI for GlWindowDevice {
             (gl::NO_ERROR, gl::FRAMEBUFFER_COMPLETE)
         );
 
-        self.gl.clear_color(0.2, 0.3, 0.3, 1.0);
+        self.gl.clear_color(0.0, 0.0, 0.0, 0.0);
         self.gl.clear(gl::COLOR_BUFFER_BIT);
         debug_assert_eq!(self.gl.get_error(), gl::NO_ERROR);
 

--- a/webxr/glwindow/mod.rs
+++ b/webxr/glwindow/mod.rs
@@ -436,6 +436,14 @@ impl GlWindowDevice {
             (gl::NO_ERROR, gl::FRAMEBUFFER_COMPLETE)
         );
 
+        gl.enable(gl::BLEND);
+        gl.blend_func_separate(
+            gl::SRC_ALPHA,
+            gl::ONE_MINUS_SRC_ALPHA,
+            gl::ONE,
+            gl::ONE_MINUS_SRC_ALPHA,
+        );
+
         let swap_chains = SwapChains::new();
         let layer_manager = None;
 


### PR DESCRIPTION
This change gets AR examples, and multi-layer examples from WebXR Layers to work.