### PR TITLE
Update euclid to 0.22 and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,8 @@ members = [
     "webxr",
     "webxr-api"
 ]
+
+[patch.crates-io]
+# TODO(bryce): Remove this when the PR is merged: https://github.com/servo/surfman/pull/234
+surfman = { git = "https://github.com/Bryce-MW/surfman", branch = "euclid-update" }
+surfman-chains = { git = "https://github.com/Bryce-MW/surfman", branch = "euclid-update" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ members = [
 [patch.crates-io]
 # TODO(bryce): Remove this when the PR is merged: https://github.com/servo/surfman/pull/234
 surfman = { git = "https://github.com/Bryce-MW/surfman", branch = "euclid-update" }
-surfman-chains = { git = "https://github.com/Bryce-MW/surfman", branch = "euclid-update" }
+# TODO(bryce): Remove this  when the PR is merged: https://github.com/asajeffrey/surfman-chains/pull/12
+surfman-chains = { git = "https://github.com/Bryce-MW/surfman-chains", branch = "euclid-update" }

--- a/webxr-api/Cargo.toml
+++ b/webxr-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webxr-api"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["The Servo Project Developers"]
 edition = "2018"
 
@@ -23,7 +23,7 @@ ipc = ["serde", "ipc-channel", "euclid/serde"]
 profile = ["time"]
 
 [dependencies]
-euclid = "0.20"
+euclid = "0.22"
 ipc-channel = { version = "0.14", optional = true }
 log = "0.4"
 serde = { version = "1.0", optional = true }

--- a/webxr-api/util.rs
+++ b/webxr-api/util.rs
@@ -107,7 +107,7 @@ pub fn frustum_to_projection_matrix<T, U>(
     let h = top - bottom;
     let d = far - near;
 
-    Transform3D::column_major(
+    Transform3D::new(
         2. * near / w,
         0.,
         (right + left) / w,

--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webxr"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["The Servo Project Developers"]
 edition = "2018"
 
@@ -37,14 +37,14 @@ profile = ["webxr-api/profile"]
 [dependencies]
 webxr-api = { path = "../webxr-api" }
 crossbeam-channel = "0.4"
-euclid = "0.20.10"
+euclid = "0.22"
 log = "0.4.6"
 gvr-sys = { version = "0.7", optional = true }
 openxr = { git = "https://github.com/servo/openxrs.git", branch="secondary-views-2", optional = true }
 serde = { version = "1.0", optional = true }
 sparkle = "0.1"
-surfman = "0.4"
-surfman-chains = "0.6"
+surfman = "0.5"
+surfman-chains = "0.7"
 time = "0.1.42"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/webxr/glwindow/mod.rs
+++ b/webxr/glwindow/mod.rs
@@ -234,7 +234,7 @@ impl DeviceAPI for GlWindowDevice {
             RigidTransform3D::from_translation(translation);
         let rotation = Rotation3D::from_untyped(&self.window.get_rotation());
         let rotation = RigidTransform3D::from_rotation(rotation);
-        let transform = translation.post_transform(&rotation);
+        let transform = translation.then(&rotation);
         let sub_images = self.layer_manager().ok()?.begin_frame(layers).ok()?;
         Some(Frame {
             pose: Some(ViewerPose {
@@ -606,7 +606,7 @@ impl GlWindowDevice {
         let transform: RigidTransform3D<f32, Viewer, Eye> =
             RigidTransform3D::new(rotation, translation);
         View {
-            transform: viewer.pre_transform(&transform.inverse()),
+            transform: transform.inverse().then(&viewer),
             projection,
         }
     }
@@ -630,7 +630,7 @@ impl GlWindowDevice {
         {
             #[rustfmt::skip]
             // Sigh, row-major vs column-major
-            return Transform3D::row_major(
+            return Transform3D::new(
                 f / aspect, 0.0, 0.0,                   0.0,
                 0.0,        f,   0.0,                   0.0,
                 0.0,        0.0, (far + near) * nf,     -1.0,

--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -216,7 +216,7 @@ fn view<Eye>(
     };
 
     View {
-        transform: viewer.pre_transform(&init.transform.inverse()),
+        transform: init.transform.inverse().then(&viewer),
         projection,
     }
 }
@@ -560,11 +560,11 @@ impl HeadlessDeviceData {
                 .cast_unit(),
             BaseSpace::Joint(..) => panic!("Cannot request mocking backend with hands"),
         };
-        let space_origin = origin.pre_transform(&space.offset);
+        let space_origin = space.offset.then(&origin);
 
         let origin_rigid: RigidTransform3D<f32, ApiSpace, ApiSpace> = ray.origin.into();
         Some(Ray {
-            origin: origin_rigid.post_transform(&space_origin).translation,
+            origin: origin_rigid.then(&space_origin).translation,
             direction: space_origin.rotation.transform_vector3d(ray.direction),
         })
     }


### PR DESCRIPTION
Note, this relies on surfman being updated to Euclid 0.22. I have put in a patch for now but that will need to be removed when [the PR](https://github.com/servo/surfman/pull/234) is merged. It also relies on surfman chains being updated which further relies on surfman. [The PR for that is here](https://github.com/asajeffrey/surfman-chains/pull/12). It will work fine until then. I bumped the version because updating Euclid is a breaking change.

I am not 100% sure on the whole `Transform3D::column_major` and `Transform3D::row_major`. The docs for Euclid claim that `::new` is column-major but [this commit](https://github.com/servo/webrender/pull/4063/files) to webrender seems to use it as row major without any modifications. Maybe I'm not understanding something though, my linear algebra class was during covid so it wasn't the best. It seems like this works fine but I'm happy to have a more in-depth look at exactly what should happen.

`post_transform` is a multiplication with the argument on the right so we can use the new  `then` method. `post_transform` is multiplication with the argument on the left so we basically have to reverse the other of things (i.e.  `A.pre_transform(&B) == B.then(&A)`)

This is part of my effort to update the version of webrender used by Servo. I have made [an issue on the Servo repository](https://github.com/servo/servo/issues/28585) to keep track.