### PR TITLE
Update surfman to 0.6

### DIFF
--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -43,7 +43,7 @@ gvr-sys = { version = "0.7", optional = true }
 openxr = { git = "https://github.com/servo/openxrs.git", branch="secondary-views-2", optional = true }
 serde = { version = "1.0", optional = true }
 sparkle = "0.1"
-surfman = "0.5"
+surfman = "0.6"
 surfman-chains = "0.7"
 time = "0.1.42"
 


### PR DESCRIPTION
To complete the update of winit used by Servo (servo/servo#29382), a new version 0.6.0 of surfman has been published to crates.io (servo/surfman#249). To address compilation errors in Servo about mismatched types due to duplicated versions of surfman, we will need to update all references in Servo to the same version (0.6.0).