### PR TITLE
Update to ipc-channel v0.16 & crossbeam-channel v0.5

### DIFF
--- a/webxr-api/Cargo.toml
+++ b/webxr-api/Cargo.toml
@@ -24,7 +24,7 @@ profile = ["time"]
 
 [dependencies]
 euclid = "0.22"
-ipc-channel = { version = "0.14", optional = true }
+ipc-channel = { version = "0.16", optional = true }
 log = "0.4"
 serde = { version = "1.0", optional = true }
 time = { version = "0.1", optional = true }

--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -36,7 +36,7 @@ profile = ["webxr-api/profile"]
 
 [dependencies]
 webxr-api = { path = "../webxr-api" }
-crossbeam-channel = "0.4"
+crossbeam-channel = "0.5"
 euclid = "0.22"
 log = "0.4.6"
 gvr-sys = { version = "0.7", optional = true }


### PR DESCRIPTION
ipc-channel used in servo needs to bumped to 0.16.1 to complete servo/servo#29467, but that requires the same version to be used by webxr crates as well.