### PR TITLE
Row-major -> Column-major on projection matrix

### DIFF
--- a/webxr-api/util.rs
+++ b/webxr-api/util.rs
@@ -107,22 +107,23 @@ pub fn frustum_to_projection_matrix<T, U>(
     let h = top - bottom;
     let d = far - near;
 
+    // Column-major order
     Transform3D::new(
         2. * near / w,
         0.,
-        (right + left) / w,
+        0.,
         0.,
         0.,
         2. * near / h,
+        0.,
+        0.,
+        (right + left) / w,
         (top + bottom) / h,
-        0.,
-        0.,
-        0.,
         -(far + near) / d,
-        -2. * far * near / d,
-        0.,
-        0.,
         -1.,
+        0.,
+        0.,
+        -2. * far * near / d,
         0.,
     )
 }


### PR DESCRIPTION
As discovered during my [experimentation](https://twitter.com/msub2official/status/1677879727556624384) the projection matrix was being constructed in row-major order, but [WebXR expects it to be column-major](https://www.w3.org/TR/webxr/#matrices).