### PR TITLE
Upgrade surfman to 0.9.0

### DIFF
--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -43,7 +43,7 @@ gvr-sys = { version = "0.7", optional = true }
 openxr = { git = "https://github.com/servo/openxrs.git", branch="secondary-views-2", optional = true }
 serde = { version = "1.0", optional = true }
 sparkle = "0.1"
-surfman = { version = "0.8", features = ["chains"] }
+surfman = { version = "0.9", features = ["chains"] }
 time = "0.1.42"
 
 [target.'cfg(target_os = "windows")'.dependencies]


### PR DESCRIPTION
This allows us to remove the winit dependency.
