### PR TITLE
Use upstream OpenXRS

### DIFF
--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -40,7 +40,7 @@ crossbeam-channel = "0.5"
 euclid = "0.22"
 log = "0.4.6"
 gvr-sys = { version = "0.7", optional = true }
-openxr = { git = "https://github.com/servo/openxrs.git", branch="secondary-views-2", optional = true }
+openxr = { version = "0.17", optional = true }
 serde = { version = "1.0", optional = true }
 sparkle = "0.1"
 surfman = { version = "0.8", features = ["chains"] }


### PR DESCRIPTION
Instead of using Servo's forked version, use the one from upstream
which now incorporates our changes.
