### PR TITLE
Update surfman to latest

### DIFF
--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -43,7 +43,7 @@ gvr-sys = { version = "0.7", optional = true }
 openxr = { git = "https://github.com/servo/openxrs.git", branch="d3d-types", optional = true }
 serde = { version = "1.0", optional = true }
 sparkle = "0.1"
-surfman = { version = "0.9", features = ["chains"] }
+surfman = { version = "0.9", features = ["chains"], git = "https://github.com/servo/surfman", rev = "f7eb174517e842755e5faec91fa8c6928c76a5ae" }
 time = "0.1.42"
 
 [target.'cfg(target_os = "windows")'.dependencies]


### PR DESCRIPTION
I don't think servo webxr should depend on the git version of surfman, hence this is a draft until surfman 0.10 is released to crates.io.