### PR TITLE
Use `openxrs` from crates.io

### DIFF
--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -40,7 +40,7 @@ crossbeam-channel = "0.5"
 euclid = "0.22"
 log = "0.4.6"
 gvr-sys = { version = "0.7", optional = true }
-openxr = { git = "https://github.com/servo/openxrs.git", branch="d3d-types", optional = true }
+openxr = { version = "0.18", optional = true }
 serde = { version = "1.0", optional = true }
 sparkle = "0.1"
 surfman = { version = "0.9", features = ["chains"] }


### PR DESCRIPTION
A new version has been released so we don't need to use our fork any longer.