### PR TITLE
Support OpenXR runtimes that do not support fovMutable

### DIFF
--- a/webxr/gl_utils.rs
+++ b/webxr/gl_utils.rs
@@ -21,7 +21,10 @@ pub(crate) struct GlClearer {
 impl GlClearer {
     pub(crate) fn new(should_reverse_winding: bool) -> GlClearer {
         let fbos = HashMap::new();
-        GlClearer { fbos, should_reverse_winding }
+        GlClearer {
+            fbos,
+            should_reverse_winding,
+        }
     }
 
     fn fbo(

--- a/webxr/surfman_layer_manager.rs
+++ b/webxr/surfman_layer_manager.rs
@@ -41,7 +41,7 @@ impl SurfmanLayerManager {
         let layers = Vec::new();
         let surface_textures = HashMap::new();
         let depth_stencil_textures = HashMap::new();
-        let clearer = GlClearer::new();
+        let clearer = GlClearer::new(false);
         SurfmanLayerManager {
             layers,
             swap_chains,


### PR DESCRIPTION
Fixes #216. This allows for proper rendering with the Oculus/Quest Link runtime by swapping up/down angles before setting views and reversing winding order, as it does not allow for swapping fov angles during composition layer submission.

Worth noting this will need adjustment if this code ever stops assuming that sessions are using D3D11, especially for future Linux support.