### PR TITLE
Remove use of `time`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
         cd webxr
         cargo build --features=glwindow,headless
         cargo build --features=ipc,glwindow,headless
-        cargo build --features=glwindow,headless,profile
+        cargo build --features=glwindow,headless
   mac:
     runs-on: macos-latest
     steps:
@@ -39,7 +39,7 @@ jobs:
         cd webxr
         cargo build --features=glwindow,headless
         cargo build --features=ipc,glwindow,headless
-        cargo build --features=glwindow,headless,profile
+        cargo build --features=glwindow,headless
   win:
     runs-on: windows-latest
     steps:
@@ -50,7 +50,7 @@ jobs:
         cd webxr
         cargo build --features=glwindow,headless
         cargo build --features=ipc,glwindow,headless
-        cargo build --features=glwindow,headless,profile
+        cargo build --features=glwindow,headless
         rustup target add aarch64-pc-windows-msvc
         cargo build --target=aarch64-pc-windows-msvc --features ipc,openxr-api
   build_result:

--- a/webxr-api/Cargo.toml
+++ b/webxr-api/Cargo.toml
@@ -19,7 +19,6 @@ path = "lib.rs"
 
 [features]
 ipc = ["serde", "ipc-channel", "euclid/serde"]
-profile = ["time"]
 
 [dependencies]
 euclid = "0.22"

--- a/webxr-api/frame.rs
+++ b/webxr-api/frame.rs
@@ -31,12 +31,6 @@ pub struct Frame {
     /// The subimages to render to
     pub sub_images: Vec<SubImages>,
 
-    /// Value of time::precise_time_ns() when frame was obtained
-    pub time_ns: u64,
-
-    /// The time the frame was sent (only set with the profile feature)
-    pub sent_time: u64,
-
     /// The hit test results for this frame, if any
     pub hit_test_results: Vec<HitTestResult>,
 }

--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -25,7 +25,6 @@ glwindow = []
 headless = []
 ipc = ["webxr-api/ipc", "serde"]
 openxr-api = ["angle", "openxr", "winapi", "wio", "surfman/sm-angle-default"]
-profile = ["webxr-api/profile"]
 
 [dependencies]
 webxr-api = { path = "../webxr-api" }
@@ -36,7 +35,6 @@ openxr = { version = "0.18", optional = true }
 serde = { version = "1.0", optional = true }
 sparkle = "0.1"
 surfman = { version = "0.9", features = ["chains"] }
-time = "0.1.42"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["dxgi", "d3d11", "winerror"], optional = true }

--- a/webxr/glwindow/mod.rs
+++ b/webxr/glwindow/mod.rs
@@ -176,7 +176,6 @@ impl DeviceAPI for GlWindowDevice {
 
     fn begin_animation_frame(&mut self, layers: &[(ContextId, LayerId)]) -> Option<Frame> {
         log::debug!("Begin animation frame for layers {:?}", layers);
-        let time_ns = time::precise_time_ns();
         let translation = Vector3D::from_untyped(self.window.get_translation());
         let translation: RigidTransform3D<_, _, Native> =
             RigidTransform3D::from_translation(translation);
@@ -191,9 +190,7 @@ impl DeviceAPI for GlWindowDevice {
             }),
             inputs: vec![],
             events: vec![],
-            time_ns,
             sub_images,
-            sent_time: 0,
             hit_test_results: vec![],
         })
     }

--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -323,7 +323,6 @@ macro_rules! with_all_sessions {
 
 impl HeadlessDeviceData {
     fn get_frame(&self, s: &PerSessionData, sub_images: Vec<SubImages>) -> Frame {
-        let time_ns = time::precise_time_ns();
         let views = self.views.clone();
 
         let pose = self.viewer_origin.map(|transform| {
@@ -358,9 +357,7 @@ impl HeadlessDeviceData {
             pose,
             inputs,
             events: vec![],
-            time_ns,
             sub_images,
-            sent_time: 0,
             hit_test_results: vec![],
         }
     }

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -1237,7 +1237,6 @@ impl DeviceAPI for OpenXrDevice {
 
         let mut guard = self.shared_data.lock().unwrap();
         let data = guard.as_mut().unwrap();
-        let time_ns = time::precise_time_ns();
 
         // XXXManishearth should we check frame_state.should_render?
         let (_view_flags, mut views) = match self.session.locate_views(
@@ -1327,9 +1326,7 @@ impl DeviceAPI for OpenXrDevice {
             pose: Some(ViewerPose { transform, views }),
             inputs: vec![right.frame, left.frame],
             events: vec![],
-            time_ns,
             sub_images,
-            sent_time: 0,
             hit_test_results: vec![],
         };
 


### PR DESCRIPTION
A very ancient version of `time` was used with security vulnerabilities.
Remove all uses of time including the `profile` feature. Hopefully in
the future, some of this functionality can be restored, but in the
meantime get Servo closer to no longer using old `time`.
