### PR TITLE
OpenXR: Expose button/axis inputs for WebXR gamepads

### DIFF
--- a/webxr-api/events.rs
+++ b/webxr-api/events.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::Frame;
+use crate::InputFrame;
 use crate::InputId;
 use crate::InputSource;
 use crate::SelectEvent;
@@ -24,6 +25,7 @@ pub enum Event {
     VisibilityChange(Visibility),
     /// Selection started / ended
     Select(InputId, SelectKind, SelectEvent, Frame),
+    InputChanged(InputId, InputFrame),
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/webxr-api/input.rs
+++ b/webxr-api/input.rs
@@ -49,6 +49,9 @@ pub struct InputFrame {
     pub pressed: bool,
     pub hand: Option<Box<Hand<JointFrame>>>,
     pub squeezed: bool,
+    pub button_values: Vec<f32>,
+    pub axis_values: Vec<f32>,
+    pub input_changed: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -351,6 +351,9 @@ impl HeadlessDeviceData {
                 pressed: false,
                 squeezed: false,
                 hand: None,
+                button_values: vec![],
+                axis_values: vec![],
+                input_changed: false,
             })
             .collect();
         Frame {

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -1414,6 +1414,9 @@ impl DeviceAPI for OpenXrDevice {
             }
         }
 
+        let left_input_changed = left.frame.input_changed;
+        let right_input_changed = right.frame.input_changed;
+
         let frame = Frame {
             pose: Some(ViewerPose { transform, views }),
             inputs: vec![right.frame, left.frame],
@@ -1453,6 +1456,14 @@ impl DeviceAPI for OpenXrDevice {
                 left_squeeze,
                 frame.clone(),
             ));
+        }
+        if left_input_changed {
+            self.events
+                .callback(Event::InputChanged(InputId(1), frame.inputs[1].clone()))
+        }
+        if right_input_changed {
+            self.events
+                .callback(Event::InputChanged(InputId(0), frame.inputs[0].clone()))
         }
         Some(frame)
     }


### PR DESCRIPTION
This extends the current input handling in the OpenXR backend to expose button and axis inputs for use with the WebXR gamepads module. It will require an update in Servo as well to handle the new event for changed input.