### PR TITLE
OpenXR: Add interaction profiles for hand tracking

### DIFF
--- a/webxr/openxr/input.rs
+++ b/webxr/openxr/input.rs
@@ -30,7 +30,7 @@ use super::interaction_profiles::InteractionProfile;
 use super::IDENTITY_POSE;
 
 use crate::ext_string;
-use crate::openxr::interaction_profiles::{InteractionProfileType, INTERACTION_PROFILES};
+use crate::openxr::interaction_profiles::INTERACTION_PROFILES;
 
 /// Number of frames to wait with the menu gesture before
 /// opening the menu.

--- a/webxr/openxr/input.rs
+++ b/webxr/openxr/input.rs
@@ -551,14 +551,14 @@ impl OpenXRInput {
 
         let mut aim_state: Option<HandTrackingAimStateFB> = None;
         let hand = self.hand_tracker.as_ref().and_then(|tracker| {
-            Some(locate_hand(
+            locate_hand(
                 base_space,
                 tracker,
                 frame_state,
                 self.use_alternate_input_source,
                 session,
                 &mut aim_state,
-            ))?
+            )
         });
 
         let mut pressed = click_is_active && click.current_state;

--- a/webxr/openxr/input.rs
+++ b/webxr/openxr/input.rs
@@ -78,12 +78,18 @@ impl ClickState {
     ) -> (/* is_active */ bool, Option<SelectEvent>) {
         let click = action.state(session, Path::NULL).unwrap();
 
-        let select_event = self.update_from_value(click.current_state, click.is_active, menu_selected);
+        let select_event =
+            self.update_from_value(click.current_state, click.is_active, menu_selected);
 
         (click.is_active, select_event)
     }
 
-    fn update_from_value(&mut self, current_state: bool, is_active: bool, menu_selected: bool) -> Option<SelectEvent> {
+    fn update_from_value(
+        &mut self,
+        current_state: bool,
+        is_active: bool,
+        menu_selected: bool,
+    ) -> Option<SelectEvent> {
         if is_active {
             match (current_state, *self) {
                 (_, ClickState::Clicking) if menu_selected => {
@@ -110,7 +116,6 @@ impl ClickState {
         }
     }
 }
-
 
 pub struct OpenXRInput {
     id: InputId,
@@ -277,7 +282,8 @@ impl OpenXRInput {
             vec![axis1, axis2, axis3, axis4]
         };
 
-        let use_alternate_input_source = supported_interaction_profiles.contains(&ext_string!(FB_HAND_TRACKING_AIM_EXTENSION_NAME));
+        let use_alternate_input_source = supported_interaction_profiles
+            .contains(&ext_string!(FB_HAND_TRACKING_AIM_EXTENSION_NAME));
 
         Self {
             id,

--- a/webxr/openxr/interaction_profiles.rs
+++ b/webxr/openxr/interaction_profiles.rs
@@ -1,7 +1,8 @@
 use openxr::{
     sys::{
         BD_CONTROLLER_INTERACTION_EXTENSION_NAME, EXT_HP_MIXED_REALITY_CONTROLLER_EXTENSION_NAME,
-        EXT_SAMSUNG_ODYSSEY_CONTROLLER_EXTENSION_NAME, FB_TOUCH_CONTROLLER_PRO_EXTENSION_NAME,
+        EXT_SAMSUNG_ODYSSEY_CONTROLLER_EXTENSION_NAME, FB_HAND_TRACKING_AIM_EXTENSION_NAME,
+        FB_TOUCH_CONTROLLER_PRO_EXTENSION_NAME,
         HTC_VIVE_COSMOS_CONTROLLER_INTERACTION_EXTENSION_NAME,
         HTC_VIVE_FOCUS3_CONTROLLER_INTERACTION_EXTENSION_NAME,
         META_TOUCH_CONTROLLER_PLUS_EXTENSION_NAME, ML_ML2_CONTROLLER_INTERACTION_EXTENSION_NAME,
@@ -16,7 +17,7 @@ macro_rules! ext_string {
     };
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum InteractionProfileType {
     KhrSimpleController,
     BytedancePicoNeo3Controller,
@@ -38,10 +39,10 @@ pub enum InteractionProfileType {
     MetaTouchControllerQuest2,
     SamsungOdysseyController,
     ValveIndexController,
+    FbHandTrackingAim,
 }
 
 #[derive(Clone, Copy, Debug)]
-#[allow(unused)]
 pub struct InteractionProfile<'a> {
     pub profile_type: InteractionProfileType,
     /// The interaction profile path
@@ -334,7 +335,18 @@ pub static VALVE_INDEX_CONTROLLER_PROFILE: InteractionProfile = InteractionProfi
     profiles: &["valve-index", "generic-trigger-squeeze-touchpad-thumbstick"],
 };
 
-pub static INTERACTION_PROFILES: [InteractionProfile; 20] = [
+pub static FB_HAND_TRACKING_AIM_PROFILE: InteractionProfile = InteractionProfile {
+    profile_type: InteractionProfileType::FbHandTrackingAim,
+    path: "",
+    required_extension: Some(FB_HAND_TRACKING_AIM_EXTENSION_NAME),
+    standard_buttons: &["", "", "", ""],
+    standard_axes: &["", "", "", ""],
+    left_buttons: &[],
+    right_buttons: &[],
+    profiles: &["generic-hand-select", "generic-hand"],
+};
+
+pub static INTERACTION_PROFILES: [InteractionProfile; 21] = [
     KHR_SIMPLE_CONTROLLER_PROFILE,
     BYTEDANCE_PICO_NEO3_CONTROLLER_PROFILE,
     BYTEDANCE_PICO_4_CONTROLLER_PROFILE,
@@ -355,6 +367,7 @@ pub static INTERACTION_PROFILES: [InteractionProfile; 20] = [
     META_TOUCH_CONTROLLER_QUEST_2_PROFILE,
     SAMSUNG_ODYSSEY_CONTROLLER_PROFILE,
     VALVE_INDEX_CONTROLLER_PROFILE,
+    FB_HAND_TRACKING_AIM_PROFILE,
 ];
 
 pub fn get_profiles_from_path(path: String) -> &'static [&'static str] {
@@ -404,6 +417,10 @@ pub fn get_supported_interaction_profiles(
     if supported_extensions.meta_touch_controller_plus {
         extensions.push(ext_string!(META_TOUCH_CONTROLLER_PLUS_EXTENSION_NAME));
         enabled_extensions.meta_touch_controller_plus = true;
+    }
+    if supported_extensions.fb_hand_tracking_aim {
+        extensions.push(ext_string!(FB_HAND_TRACKING_AIM_EXTENSION_NAME));
+        enabled_extensions.fb_hand_tracking_aim = true;
     }
     extensions
 }

--- a/webxr/openxr/interaction_profiles.rs
+++ b/webxr/openxr/interaction_profiles.rs
@@ -1,6 +1,7 @@
 use openxr::{
     sys::{
-        BD_CONTROLLER_INTERACTION_EXTENSION_NAME, EXT_HP_MIXED_REALITY_CONTROLLER_EXTENSION_NAME,
+        BD_CONTROLLER_INTERACTION_EXTENSION_NAME, EXT_HAND_INTERACTION_EXTENSION_NAME,
+        EXT_HP_MIXED_REALITY_CONTROLLER_EXTENSION_NAME,
         EXT_SAMSUNG_ODYSSEY_CONTROLLER_EXTENSION_NAME, FB_HAND_TRACKING_AIM_EXTENSION_NAME,
         FB_TOUCH_CONTROLLER_PRO_EXTENSION_NAME,
         HTC_VIVE_COSMOS_CONTROLLER_INTERACTION_EXTENSION_NAME,
@@ -39,6 +40,7 @@ pub enum InteractionProfileType {
     MetaTouchControllerQuest2,
     SamsungOdysseyController,
     ValveIndexController,
+    ExtHandInteraction,
     FbHandTrackingAim,
 }
 
@@ -335,6 +337,17 @@ pub static VALVE_INDEX_CONTROLLER_PROFILE: InteractionProfile = InteractionProfi
     profiles: &["valve-index", "generic-trigger-squeeze-touchpad-thumbstick"],
 };
 
+pub static EXT_HAND_INTERACTION_PROFILE: InteractionProfile = InteractionProfile {
+    profile_type: InteractionProfileType::ExtHandInteraction,
+    path: "interaction_profiles/ext/hand_interaction_ext",
+    required_extension: Some(EXT_HAND_INTERACTION_EXTENSION_NAME),
+    standard_buttons: &["pinch_ext/value", "", "", ""],
+    standard_axes: &["", "", "", ""],
+    left_buttons: &[],
+    right_buttons: &[],
+    profiles: &["generic-hand-select", "generic-hand"],
+};
+
 pub static FB_HAND_TRACKING_AIM_PROFILE: InteractionProfile = InteractionProfile {
     profile_type: InteractionProfileType::FbHandTrackingAim,
     path: "",
@@ -346,7 +359,7 @@ pub static FB_HAND_TRACKING_AIM_PROFILE: InteractionProfile = InteractionProfile
     profiles: &["generic-hand-select", "generic-hand"],
 };
 
-pub static INTERACTION_PROFILES: [InteractionProfile; 21] = [
+pub static INTERACTION_PROFILES: [InteractionProfile; 22] = [
     KHR_SIMPLE_CONTROLLER_PROFILE,
     BYTEDANCE_PICO_NEO3_CONTROLLER_PROFILE,
     BYTEDANCE_PICO_4_CONTROLLER_PROFILE,
@@ -367,6 +380,7 @@ pub static INTERACTION_PROFILES: [InteractionProfile; 21] = [
     META_TOUCH_CONTROLLER_QUEST_2_PROFILE,
     SAMSUNG_ODYSSEY_CONTROLLER_PROFILE,
     VALVE_INDEX_CONTROLLER_PROFILE,
+    EXT_HAND_INTERACTION_PROFILE,
     FB_HAND_TRACKING_AIM_PROFILE,
 ];
 
@@ -417,6 +431,10 @@ pub fn get_supported_interaction_profiles(
     if supported_extensions.meta_touch_controller_plus {
         extensions.push(ext_string!(META_TOUCH_CONTROLLER_PLUS_EXTENSION_NAME));
         enabled_extensions.meta_touch_controller_plus = true;
+    }
+    if supported_extensions.ext_hand_interaction {
+        extensions.push(ext_string!(EXT_HAND_INTERACTION_EXTENSION_NAME));
+        enabled_extensions.ext_hand_interaction = true;
     }
     if supported_extensions.fb_hand_tracking_aim {
         extensions.push(ext_string!(FB_HAND_TRACKING_AIM_EXTENSION_NAME));


### PR DESCRIPTION
This expands the handling for hand tracking in OpenXR to be able to better get both aim pose and select status from hand trackers, as previously it was relying on hardcoded actions that don't exist in every runtime. This should supersede #151 as well