### PR TITLE
Surface framerate info/functionality

### DIFF
--- a/webxr-api/device.rs
+++ b/webxr-api/device.rs
@@ -84,6 +84,14 @@ pub trait DeviceAPI: 'static {
     fn cancel_hit_test(&mut self, _id: HitTestId) {
         panic!("This device does not support hit tests");
     }
+
+    fn update_frame_rate(&mut self, rate: f32) -> f32 {
+        rate
+    }
+
+    fn supported_frame_rates(&self) -> Vec<f32> {
+        Vec::new()
+    }
 }
 
 impl<GL: 'static> DiscoveryAPI<GL> for Box<dyn DiscoveryAPI<GL>> {


### PR DESCRIPTION
This PR surfaces framerate info from the OpenXR runtime, which in turn helps support some of the newer features on XRSession like `XRSession.frameRate`, `XRSession.supportedFrameRates`, and `XRSession.updateTargetFrameRate`

Fixes #237