### PR TITLE
Surface predicted display time on Frame object

### DIFF
--- a/webxr-api/frame.rs
+++ b/webxr-api/frame.rs
@@ -33,6 +33,9 @@ pub struct Frame {
 
     /// The hit test results for this frame, if any
     pub hit_test_results: Vec<HitTestResult>,
+
+    /// The average point in time this XRFrame is expected to be displayed on the devices' display
+    pub predicted_display_time: f64,
 }
 
 #[derive(Clone, Debug)]

--- a/webxr/glwindow/mod.rs
+++ b/webxr/glwindow/mod.rs
@@ -192,6 +192,7 @@ impl DeviceAPI for GlWindowDevice {
             events: vec![],
             sub_images,
             hit_test_results: vec![],
+            predicted_display_time: 0.0,
         })
     }
 

--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -362,6 +362,7 @@ impl HeadlessDeviceData {
             events: vec![],
             sub_images,
             hit_test_results: vec![],
+            predicted_display_time: 0.0,
         }
     }
 

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -1469,6 +1469,7 @@ impl DeviceAPI for OpenXrDevice {
             events: vec![],
             sub_images,
             hit_test_results: vec![],
+            predicted_display_time: frame_state.predicted_display_time.as_nanos() as f64,
         };
 
         if let Some(right_select) = right.select {


### PR DESCRIPTION
This adds a `predicted_display_time` to the Frame object, corresponding to `XRFrame.predictedDisplayTime`. Currently only OpenXR surfaces a real value for this, so the headless and GLWindow backends just report 0 for now.