### PR TITLE
Update bounded space handling, add support in mock

### DIFF
--- a/webxr-api/device.rs
+++ b/webxr-api/device.rs
@@ -24,8 +24,7 @@ use crate::SessionInit;
 use crate::SessionMode;
 use crate::Viewports;
 
-use euclid::Box2D;
-use euclid::RigidTransform3D;
+use euclid::{Point2D, RigidTransform3D};
 
 /// A trait for discovering XR devices
 pub trait DiscoveryAPI<GL>: 'static {
@@ -94,7 +93,7 @@ pub trait DeviceAPI: 'static {
         Vec::new()
     }
 
-    fn reference_space_bounds(&self) -> Option<Box2D<f32, Floor>> {
+    fn reference_space_bounds(&self) -> Option<Vec<Point2D<f32, Floor>>> {
         None
     }
 }

--- a/webxr-api/mock.rs
+++ b/webxr-api/mock.rs
@@ -24,7 +24,7 @@ use crate::Viewer;
 use crate::Viewport;
 use crate::Visibility;
 
-use euclid::{Rect, RigidTransform3D, Transform3D};
+use euclid::{Point2D, Rect, RigidTransform3D, Transform3D};
 
 #[cfg(feature = "ipc")]
 use serde::{Deserialize, Serialize};
@@ -80,6 +80,7 @@ pub enum MockDeviceMsg {
     SetWorld(MockWorld),
     ClearWorld,
     Disconnect(Sender<()>),
+    SetBoundsGeometry(Vec<Point2D<f32, Floor>>),
 }
 
 #[derive(Clone, Debug)]

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -1523,7 +1523,7 @@ impl DeviceAPI for OpenXrDevice {
         }
     }
 
-    fn reference_space_bounds(&self) -> Option<Box2D<f32, Floor>> {
+    fn reference_space_bounds(&self) -> Option<Vec<Point2D<f32, Floor>>> {
         match self
             .session
             .reference_space_bounds_rect(ReferenceSpaceType::STAGE)
@@ -1534,7 +1534,7 @@ impl DeviceAPI for OpenXrDevice {
                     let point2 = Point2D::new(-bounds.width / 2., bounds.height / 2.);
                     let point3 = Point2D::new(bounds.width / 2., bounds.height / 2.);
                     let point4 = Point2D::new(bounds.width / 2., -bounds.height / 2.);
-                    Some(Box2D::from_points([point1, point2, point3, point4]))
+                    Some(vec![point1, point2, point3, point4])
                 } else {
                     None
                 }


### PR DESCRIPTION
In my initial implementation I represented reference space bounds with a Box2D, as those extents are what OpenXR returns. However, the bounds geometry can technically be an arbitrary length, and the WPT tests do in fact test for this. This changes the bounds geometry to be represented as a Vec of Point2Ds instead, as well as adding support for updating bounds geometry in the mock device.