### PR TITLE
Support SteamVR-backed sessions for OpenXR

### DIFF
--- a/webxr/openxr/graphics_d3d11.rs
+++ b/webxr/openxr/graphics_d3d11.rs
@@ -35,6 +35,7 @@ impl GraphicsProviderMethods<D3D11> for GraphicsProvider {
         warn!("Available formats: {:?}", formats);
         for format in formats {
             match *format {
+                dxgiformat::DXGI_FORMAT_B8G8R8A8_UNORM_SRGB => return *format,
                 dxgiformat::DXGI_FORMAT_B8G8R8A8_UNORM => return *format,
                 //dxgiformat::DXGI_FORMAT_R8G8B8A8_UNORM => return *format,
                 f => {


### PR DESCRIPTION
This PR allows for OpenXR sessions to function properly with SteamVR as well as Oculus. It adds `DXGI_FORMAT_B8G8R8A8_UNORM_SRGB` to `pick_format` for D3D11, as SteamVR does not take `DXGI_FORMAT_B8G8R8A8_UNORM`. There doesn't appear to be any noticable performance hit from gamma correction, and indeed it actually displays colors in the session more accurately than Oculus runtime, which is not running gamma correction currently. It also adjusts the manipulation of views, as it turns out that just flipping the up/down angles on the FOVs during composition layer submission is no longer sufficient. It seems that as long as windows sessions are solely backed by D3D11, we'll need to apply the same inverted view + reversed winding fix for SteamVR as well as Oculus.

Fixes #217 