### PR TITLE
Add support for reference space change events

### DIFF
--- a/webxr-api/events.rs
+++ b/webxr-api/events.rs
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use euclid::RigidTransform3D;
+
+use crate::ApiSpace;
+use crate::BaseSpace;
 use crate::Frame;
 use crate::InputFrame;
 use crate::InputId;
@@ -25,7 +29,10 @@ pub enum Event {
     VisibilityChange(Visibility),
     /// Selection started / ended
     Select(InputId, SelectKind, SelectEvent, Frame),
+    /// Input from an input source has changed
     InputChanged(InputId, InputFrame),
+    /// Reference space has changed
+    ReferenceSpaceChanged(BaseSpace, RigidTransform3D<f32, ApiSpace, ApiSpace>),
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/webxr-api/mock.rs
+++ b/webxr-api/mock.rs
@@ -81,6 +81,7 @@ pub enum MockDeviceMsg {
     ClearWorld,
     Disconnect(Sender<()>),
     SetBoundsGeometry(Vec<Point2D<f32, Floor>>),
+    SimulateResetPose,
 }
 
 #[derive(Clone, Debug)]

--- a/webxr-api/space.rs
+++ b/webxr-api/space.rs
@@ -8,7 +8,7 @@ use euclid::RigidTransform3D;
 /// it comes from client side code"
 pub struct ApiSpace;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
 pub enum BaseSpace {
     Local,

--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -523,6 +523,11 @@ impl HeadlessDeviceData {
             MockDeviceMsg::SetBoundsGeometry(g) => {
                 self.bounds_geometry = g;
             }
+            MockDeviceMsg::SimulateResetPose => {
+                with_all_sessions!(self, |s| s
+                    .events
+                    .callback(Event::ReferenceSpaceChanged(BaseSpace::Local, RigidTransform3D::identity())));
+            }
         }
         true
     }

--- a/webxr/headless/mod.rs
+++ b/webxr/headless/mod.rs
@@ -524,9 +524,10 @@ impl HeadlessDeviceData {
                 self.bounds_geometry = g;
             }
             MockDeviceMsg::SimulateResetPose => {
-                with_all_sessions!(self, |s| s
-                    .events
-                    .callback(Event::ReferenceSpaceChanged(BaseSpace::Local, RigidTransform3D::identity())));
+                with_all_sessions!(self, |s| s.events.callback(Event::ReferenceSpaceChanged(
+                    BaseSpace::Local,
+                    RigidTransform3D::identity()
+                )));
             }
         }
         true

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -1169,7 +1169,9 @@ impl OpenXrDevice {
                         ReferenceSpaceType::LOCAL => BaseSpace::Local,
                         ReferenceSpaceType::LOCAL_FLOOR => BaseSpace::Floor,
                         ReferenceSpaceType::STAGE => BaseSpace::BoundedFloor,
-                        _ => unreachable!("Should not be receiving change events for unsupported space types"),
+                        _ => unreachable!(
+                            "Should not be receiving change events for unsupported space types"
+                        ),
                     };
                     let transform = transform(&e.pose_in_previous_space());
                     self.events


### PR DESCRIPTION
This adds support for reference space change events for OpenXR and mock backends.