### PR TITLE
Use glow instead of sparkle

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: Rust
 
-on: 
+on:
   push:
     branches: [main]
   pull_request:
@@ -14,45 +14,45 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: dtolnay/rust-toolchain@stable
-    - name: fmt check
-      run: cargo fmt --all -- --check
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - name: fmt check
+        run: cargo fmt --all -- --check
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: dtolnay/rust-toolchain@stable
-    - name: build
-      run: |
-        cd webxr
-        cargo build --features=glwindow,headless
-        cargo build --features=ipc,glwindow,headless
-        cargo build --features=glwindow,headless
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - name: build
+        run: |
+          cd webxr
+          cargo build --features=glwindow,headless
+          cargo build --features=ipc,glwindow,headless
+          cargo build --features=glwindow,headless
   mac:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: dtolnay/rust-toolchain@stable
-    - name: build
-      run: |
-        cd webxr
-        cargo build --features=glwindow,headless
-        cargo build --features=ipc,glwindow,headless
-        cargo build --features=glwindow,headless
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - name: build
+        run: |
+          cd webxr
+          cargo build --features=glwindow,headless
+          cargo build --features=ipc,glwindow,headless
+          cargo build --features=glwindow,headless
   win:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: dtolnay/rust-toolchain@stable
-    - name: build
-      run: |
-        cd webxr
-        cargo build --features=glwindow,headless
-        cargo build --features=ipc,glwindow,headless
-        cargo build --features=glwindow,headless
-        rustup target add aarch64-pc-windows-msvc
-        cargo build --target=aarch64-pc-windows-msvc --features ipc,openxr-api
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - name: build
+        run: |
+          cd webxr
+          cargo build --features=glwindow,headless
+          cargo build --features=ipc,glwindow,headless
+          cargo build --features=glwindow,headless
+          rustup target add aarch64-pc-windows-msvc
+          cargo build --target=aarch64-pc-windows-msvc --features ipc,openxr-api
   build_result:
     name: Result
     runs-on: ubuntu-latest

--- a/webxr-api/layer.rs
+++ b/webxr-api/layer.rs
@@ -289,6 +289,7 @@ pub struct SubImages {
 #[cfg_attr(feature = "ipc", derive(Deserialize, Serialize))]
 pub struct SubImage {
     pub color_texture: u32,
+    // TODO: make this Option<NonZeroU32>
     pub depth_stencil_texture: Option<u32>,
     pub texture_array_index: Option<u32>,
     pub viewport: Rect<i32, Viewport>,

--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -33,9 +33,13 @@ euclid = "0.22"
 log = "0.4.6"
 openxr = { version = "0.19", optional = true }
 serde = { version = "1.0", optional = true }
-glow = "0.14.2"
+glow = "0.15"
 surfman = { version = "0.9", features = ["chains"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["dxgi", "d3d11", "winerror"], optional = true }
+winapi = { version = "0.3", features = [
+    "dxgi",
+    "d3d11",
+    "winerror",
+], optional = true }
 wio = { version = "0.2", optional = true }

--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -33,7 +33,7 @@ euclid = "0.22"
 log = "0.4.6"
 openxr = { version = "0.19", optional = true }
 serde = { version = "1.0", optional = true }
-sparkle = "0.1"
+glow = "0.14.2"
 surfman = { version = "0.9", features = ["chains"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/webxr/Cargo.toml
+++ b/webxr/Cargo.toml
@@ -34,7 +34,9 @@ log = "0.4.6"
 openxr = { version = "0.19", optional = true }
 serde = { version = "1.0", optional = true }
 glow = "0.15"
-surfman = { version = "0.9", features = ["chains"] }
+surfman = { git = "https://github.com/servo/surfman", rev = "e0c34af64f2860bc56bc8a56e1c169a915b16aa3", features = [
+    "chains",
+] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = [

--- a/webxr/gl_utils.rs
+++ b/webxr/gl_utils.rs
@@ -3,18 +3,30 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::SurfmanGL;
-use sparkle::gl;
-use sparkle::gl::GLuint;
-use sparkle::gl::Gl;
+use glow as gl;
+use glow::Context as Gl;
+use glow::HasContext;
 use std::collections::HashMap;
+use std::num::NonZero;
 use surfman::Device as SurfmanDevice;
 use webxr_api::ContextId;
 use webxr_api::GLContexts;
 use webxr_api::LayerId;
 
+pub(crate) fn framebuffer(framebuffer: u32) -> Option<gl::NativeFramebuffer> {
+    NonZero::new(framebuffer).map(gl::NativeFramebuffer)
+}
+
 // A utility to clear a color texture and optional depth/stencil texture
 pub(crate) struct GlClearer {
-    fbos: HashMap<(LayerId, GLuint, Option<GLuint>), GLuint>,
+    fbos: HashMap<
+        (
+            LayerId,
+            Option<gl::NativeTexture>,
+            Option<gl::NativeTexture>,
+        ),
+        Option<gl::NativeFramebuffer>,
+    >,
     should_reverse_winding: bool,
 }
 
@@ -31,10 +43,10 @@ impl GlClearer {
         &mut self,
         gl: &Gl,
         layer_id: LayerId,
-        color: GLuint,
-        color_target: GLuint,
-        depth_stencil: Option<GLuint>,
-    ) -> GLuint {
+        color: Option<gl::NativeTexture>,
+        color_target: u32,
+        depth_stencil: Option<gl::NativeTexture>,
+    ) -> Option<gl::NativeFramebuffer> {
         let should_reverse_winding = self.should_reverse_winding;
         *self
             .fbos
@@ -43,41 +55,41 @@ impl GlClearer {
                 // Save the current GL state
                 let mut bound_fbos = [0, 0];
                 unsafe {
-                    gl.get_integer_v(gl::DRAW_FRAMEBUFFER_BINDING, &mut bound_fbos[0..]);
-                    gl.get_integer_v(gl::READ_FRAMEBUFFER_BINDING, &mut bound_fbos[1..]);
+                    gl.get_parameter_i32_slice(gl::DRAW_FRAMEBUFFER_BINDING, &mut bound_fbos[0..]);
+                    gl.get_parameter_i32_slice(gl::READ_FRAMEBUFFER_BINDING, &mut bound_fbos[1..]);
+
+                    // Generate and set attachments of a new FBO
+                    let fbo = gl.create_framebuffer().ok();
+
+                    gl.bind_framebuffer(gl::FRAMEBUFFER, fbo);
+                    gl.framebuffer_texture_2d(
+                        gl::FRAMEBUFFER,
+                        gl::COLOR_ATTACHMENT0,
+                        color_target,
+                        color,
+                        0,
+                    );
+                    gl.framebuffer_texture_2d(
+                        gl::FRAMEBUFFER,
+                        gl::DEPTH_STENCIL_ATTACHMENT,
+                        gl::TEXTURE_2D,
+                        depth_stencil,
+                        0,
+                    );
+
+                    // Necessary if using an OpenXR runtime that does not support mutable FOV,
+                    // as flipping the projection matrix necessitates reversing the winding order.
+                    if should_reverse_winding {
+                        gl.front_face(gl::CW);
+                    }
+
+                    // Restore the GL state
+                    gl.bind_framebuffer(gl::DRAW_FRAMEBUFFER, framebuffer(bound_fbos[0] as _));
+                    gl.bind_framebuffer(gl::READ_FRAMEBUFFER, framebuffer(bound_fbos[1] as _));
+                    debug_assert_eq!(gl.get_error(), gl::NO_ERROR);
+
+                    fbo
                 }
-
-                // Generate and set attachments of a new FBO
-                let fbo = gl.gen_framebuffers(1)[0];
-
-                gl.bind_framebuffer(gl::FRAMEBUFFER, fbo);
-                gl.framebuffer_texture_2d(
-                    gl::FRAMEBUFFER,
-                    gl::COLOR_ATTACHMENT0,
-                    color_target,
-                    color,
-                    0,
-                );
-                gl.framebuffer_texture_2d(
-                    gl::FRAMEBUFFER,
-                    gl::DEPTH_STENCIL_ATTACHMENT,
-                    gl::TEXTURE_2D,
-                    depth_stencil.unwrap_or(0),
-                    0,
-                );
-
-                // Necessary if using an OpenXR runtime that does not support mutable FOV,
-                // as flipping the projection matrix necessitates reversing the winding order.
-                if should_reverse_winding {
-                    gl.front_face(gl::CW);
-                }
-
-                // Restore the GL state
-                gl.bind_framebuffer(gl::DRAW_FRAMEBUFFER, bound_fbos[0] as GLuint);
-                gl.bind_framebuffer(gl::READ_FRAMEBUFFER, bound_fbos[1] as GLuint);
-                debug_assert_eq!(gl.get_error(), gl::NO_ERROR);
-
-                fbo
             })
     }
 
@@ -87,75 +99,70 @@ impl GlClearer {
         contexts: &mut dyn GLContexts<SurfmanGL>,
         context_id: ContextId,
         layer_id: LayerId,
-        color: GLuint,
-        color_target: GLuint,
-        depth_stencil: Option<GLuint>,
+        color: Option<glow::NativeTexture>,
+        color_target: u32,
+        depth_stencil: Option<glow::NativeTexture>,
     ) {
         let gl = match contexts.bindings(device, context_id) {
             None => return,
             Some(gl) => gl,
         };
         let fbo = self.fbo(gl, layer_id, color, color_target, depth_stencil);
-
-        // Save the current GL state
-        let mut bound_fbos = [0, 0];
-        let mut clear_color = [0., 0., 0., 0.];
-        let mut clear_depth = [0.];
-        let mut clear_stencil = [0];
-        let mut color_mask = [0, 0, 0, 0];
-        let mut depth_mask = [0];
-        let mut stencil_mask = [0];
-        let scissor_enabled = gl.is_enabled(gl::SCISSOR_TEST);
-        let rasterizer_enabled = gl.is_enabled(gl::RASTERIZER_DISCARD);
         unsafe {
-            gl.get_integer_v(gl::DRAW_FRAMEBUFFER_BINDING, &mut bound_fbos[0..]);
-            gl.get_integer_v(gl::READ_FRAMEBUFFER_BINDING, &mut bound_fbos[1..]);
-            gl.get_float_v(gl::COLOR_CLEAR_VALUE, &mut clear_color[..]);
-            gl.get_float_v(gl::DEPTH_CLEAR_VALUE, &mut clear_depth[..]);
-            gl.get_integer_v(gl::STENCIL_CLEAR_VALUE, &mut clear_stencil[..]);
-            gl.get_boolean_v(gl::DEPTH_WRITEMASK, &mut depth_mask[..]);
-            gl.get_integer_v(gl::STENCIL_WRITEMASK, &mut stencil_mask[..]);
-            gl.get_boolean_v(gl::COLOR_WRITEMASK, &mut color_mask[..]);
-        }
+            // Save the current GL state
+            let mut bound_fbos = [0, 0];
+            let mut clear_color = [0., 0., 0., 0.];
+            let mut clear_depth = [0.];
+            let mut clear_stencil = [0];
+            let color_mask;
+            let depth_mask;
+            let mut stencil_mask = [0];
+            let scissor_enabled = gl.is_enabled(gl::SCISSOR_TEST);
+            let rasterizer_enabled = gl.is_enabled(gl::RASTERIZER_DISCARD);
 
-        // Clear it
-        gl.bind_framebuffer(gl::FRAMEBUFFER, fbo);
-        gl.clear_color(0., 0., 0., 1.);
-        gl.clear_depth(1.);
-        gl.clear_stencil(0);
-        gl.disable(gl::SCISSOR_TEST);
-        gl.disable(gl::RASTERIZER_DISCARD);
-        gl.depth_mask(true);
-        gl.stencil_mask(0xFFFFFFFF);
-        gl.color_mask(true, true, true, true);
-        gl.clear(gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT | gl::STENCIL_BUFFER_BIT);
+            gl.get_parameter_i32_slice(gl::DRAW_FRAMEBUFFER_BINDING, &mut bound_fbos[0..]);
+            gl.get_parameter_i32_slice(gl::READ_FRAMEBUFFER_BINDING, &mut bound_fbos[1..]);
+            gl.get_parameter_f32_slice(gl::COLOR_CLEAR_VALUE, &mut clear_color[..]);
+            gl.get_parameter_f32_slice(gl::DEPTH_CLEAR_VALUE, &mut clear_depth[..]);
+            gl.get_parameter_i32_slice(gl::STENCIL_CLEAR_VALUE, &mut clear_stencil[..]);
+            depth_mask = gl.get_parameter_bool(gl::DEPTH_WRITEMASK);
+            gl.get_parameter_i32_slice(gl::STENCIL_WRITEMASK, &mut stencil_mask[..]);
+            color_mask = gl.get_parameter_bool_array::<4>(gl::COLOR_WRITEMASK);
 
-        // Restore the GL state
-        gl.bind_framebuffer(gl::DRAW_FRAMEBUFFER, bound_fbos[0] as GLuint);
-        gl.bind_framebuffer(gl::READ_FRAMEBUFFER, bound_fbos[1] as GLuint);
-        gl.clear_color(
-            clear_color[0],
-            clear_color[1],
-            clear_color[2],
-            clear_color[3],
-        );
-        gl.color_mask(
-            color_mask[0] != 0,
-            color_mask[1] != 0,
-            color_mask[2] != 0,
-            color_mask[3] != 0,
-        );
-        gl.clear_depth(clear_depth[0] as f64);
-        gl.clear_stencil(clear_stencil[0]);
-        gl.depth_mask(depth_mask[0] != 0);
-        gl.stencil_mask(stencil_mask[0] as gl::GLuint);
-        if scissor_enabled {
-            gl.enable(gl::SCISSOR_TEST);
+            // Clear it
+            gl.bind_framebuffer(gl::FRAMEBUFFER, fbo);
+            gl.clear_color(0., 0., 0., 1.);
+            gl.clear_depth_f64(1.);
+            gl.clear_stencil(0);
+            gl.disable(gl::SCISSOR_TEST);
+            gl.disable(gl::RASTERIZER_DISCARD);
+            gl.depth_mask(true);
+            gl.stencil_mask(0xFFFFFFFF);
+            gl.color_mask(true, true, true, true);
+            gl.clear(gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT | gl::STENCIL_BUFFER_BIT);
+
+            // Restore the GL state
+            gl.bind_framebuffer(gl::DRAW_FRAMEBUFFER, framebuffer(bound_fbos[0] as _));
+            gl.bind_framebuffer(gl::READ_FRAMEBUFFER, framebuffer(bound_fbos[1] as _));
+            gl.clear_color(
+                clear_color[0],
+                clear_color[1],
+                clear_color[2],
+                clear_color[3],
+            );
+            gl.color_mask(color_mask[0], color_mask[1], color_mask[2], color_mask[3]);
+            gl.clear_depth_f64(clear_depth[0] as f64);
+            gl.clear_stencil(clear_stencil[0]);
+            gl.depth_mask(depth_mask);
+            gl.stencil_mask(stencil_mask[0] as _);
+            if scissor_enabled {
+                gl.enable(gl::SCISSOR_TEST);
+            }
+            if rasterizer_enabled {
+                gl.enable(gl::RASTERIZER_DISCARD);
+            }
+            debug_assert_eq!(gl.get_error(), gl::NO_ERROR);
         }
-        if rasterizer_enabled {
-            gl.enable(gl::RASTERIZER_DISCARD);
-        }
-        debug_assert_eq!(gl.get_error(), gl::NO_ERROR);
     }
 
     pub(crate) fn destroy_layer(
@@ -173,7 +180,9 @@ impl GlClearer {
             if layer_id != other_id {
                 true
             } else {
-                gl.delete_framebuffers(&[fbo]);
+                if let Some(fbo) = fbo {
+                    unsafe { gl.delete_framebuffer(fbo) };
+                }
                 false
             }
         })

--- a/webxr/gl_utils.rs
+++ b/webxr/gl_utils.rs
@@ -132,7 +132,7 @@ impl GlClearer {
             // Clear it
             gl.bind_framebuffer(gl::FRAMEBUFFER, fbo);
             gl.clear_color(0., 0., 0., 1.);
-            gl.clear_depth_f64(1.);
+            gl.clear_depth(1.);
             gl.clear_stencil(0);
             gl.disable(gl::SCISSOR_TEST);
             gl.disable(gl::RASTERIZER_DISCARD);
@@ -151,7 +151,7 @@ impl GlClearer {
                 clear_color[3],
             );
             gl.color_mask(color_mask[0], color_mask[1], color_mask[2], color_mask[3]);
-            gl.clear_depth_f64(clear_depth[0] as f64);
+            gl.clear_depth(clear_depth[0] as f64);
             gl.clear_stencil(clear_stencil[0]);
             gl.depth_mask(depth_mask);
             gl.stencil_mask(stencil_mask[0] as _);

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -9,6 +9,7 @@ use euclid::Rotation3D;
 use euclid::Size2D;
 use euclid::Transform3D;
 use euclid::Vector3D;
+use glow::{self as gl, HasContext};
 use interaction_profiles::{get_profiles_from_path, get_supported_interaction_profiles};
 use log::{error, warn};
 use openxr::sys::CompositionLayerPassthroughFB;
@@ -20,10 +21,9 @@ use openxr::{
     ReferenceSpaceType, SecondaryEndInfo, Session, Space, Swapchain, SwapchainCreateFlags,
     SwapchainCreateInfo, SwapchainUsageFlags, SystemId, Vector3f, Version, ViewConfigurationType,
 };
-use sparkle::gl;
-use sparkle::gl::GLuint;
 use std::collections::HashMap;
 use std::mem;
+use std::num::NonZeroU32;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -425,7 +425,7 @@ struct OpenXrLayerManager {
 
 struct OpenXrLayer {
     swapchain: Swapchain<Backend>,
-    depth_stencil_texture: Option<GLuint>,
+    depth_stencil_texture: Option<gl::NativeTexture>,
     size: Size2D<i32, Viewport>,
     images: Vec<<Backend as Graphics>::SwapchainImage>,
     surface_textures: Vec<Option<SurfaceTexture>>,
@@ -460,7 +460,7 @@ impl OpenXrLayerManager {
 impl OpenXrLayer {
     fn new(
         swapchain: Swapchain<Backend>,
-        depth_stencil_texture: Option<GLuint>,
+        depth_stencil_texture: Option<gl::NativeTexture>,
         size: Size2D<i32, Viewport>,
     ) -> Result<OpenXrLayer, Error> {
         let images = swapchain
@@ -547,20 +547,22 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
             let gl = contexts
                 .bindings(device, context_id)
                 .ok_or(Error::NoMatchingDevice)?;
-            let depth_stencil_texture = gl.gen_textures(1)[0];
-            gl.bind_texture(gl::TEXTURE_2D, depth_stencil_texture);
-            gl.tex_image_2d(
-                gl::TEXTURE_2D,
-                0,
-                gl::DEPTH24_STENCIL8 as _,
-                texture_size.width,
-                texture_size.height,
-                0,
-                gl::DEPTH_STENCIL,
-                gl::UNSIGNED_INT_24_8,
-                gl::TexImageSource::Pixels(None),
-            );
-            Some(depth_stencil_texture)
+            unsafe {
+                let depth_stencil_texture = gl.create_texture().ok();
+                gl.bind_texture(gl::TEXTURE_2D, depth_stencil_texture);
+                gl.tex_image_2d(
+                    gl::TEXTURE_2D,
+                    0,
+                    gl::DEPTH24_STENCIL8 as _,
+                    texture_size.width,
+                    texture_size.height,
+                    0,
+                    gl::DEPTH_STENCIL,
+                    gl::UNSIGNED_INT_24_8,
+                    None,
+                );
+                depth_stencil_texture
+            }
         } else {
             None
         };
@@ -585,7 +587,7 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
         if let Some(mut layer) = self.openxr_layers.remove(&layer_id) {
             if let Some(depth_stencil_texture) = layer.depth_stencil_texture {
                 let gl = contexts.bindings(device, context_id).unwrap();
-                gl.delete_textures(&[depth_stencil_texture]);
+                unsafe { gl.delete_texture(depth_stencil_texture) };
             }
             let mut context = contexts
                 .context(device, context_id)
@@ -799,7 +801,7 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
                     })?;
                 let color_texture = device.surface_texture_object(color_surface_texture);
                 let color_target = device.surface_gl_texture_target();
-                let depth_stencil_texture = openxr_layer.depth_stencil_texture;
+                let depth_stencil_texture = openxr_layer.depth_stencil_texture.map(|nt| nt.0.get());
                 let texture_array_index = None;
                 let origin = Point2D::new(0, 0);
                 let texture_size = openxr_layer.size;
@@ -825,9 +827,9 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
                     contexts,
                     context_id,
                     layer_id,
-                    color_texture,
+                    NonZeroU32::new(color_texture).map(glow::NativeTexture),
                     color_target,
-                    depth_stencil_texture,
+                    openxr_layer.depth_stencil_texture,
                 );
                 Ok(SubImages {
                     layer_id,

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -801,7 +801,9 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
                     })?;
                 let color_texture = device.surface_texture_object(color_surface_texture);
                 let color_target = device.surface_gl_texture_target();
-                let depth_stencil_texture = openxr_layer.depth_stencil_texture.map(|texture| texture.0.get());
+                let depth_stencil_texture = openxr_layer
+                    .depth_stencil_texture
+                    .map(|texture| texture.0.get());
                 let texture_array_index = None;
                 let origin = Point2D::new(0, 0);
                 let texture_size = openxr_layer.size;

--- a/webxr/openxr/mod.rs
+++ b/webxr/openxr/mod.rs
@@ -801,7 +801,7 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
                     })?;
                 let color_texture = device.surface_texture_object(color_surface_texture);
                 let color_target = device.surface_gl_texture_target();
-                let depth_stencil_texture = openxr_layer.depth_stencil_texture.map(|nt| nt.0.get());
+                let depth_stencil_texture = openxr_layer.depth_stencil_texture.map(|texture| texture.0.get());
                 let texture_array_index = None;
                 let origin = Point2D::new(0, 0);
                 let texture_size = openxr_layer.size;

--- a/webxr/surfman_layer_manager.rs
+++ b/webxr/surfman_layer_manager.rs
@@ -174,7 +174,7 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
                     .iter()
                     .map(|&viewport| SubImage {
                         color_texture,
-                        depth_stencil_texture: depth_stencil_texture.map(|nt| nt.0.get()),
+                        depth_stencil_texture: depth_stencil_texture.map(|texture| texture.0.get()),
                         texture_array_index,
                         viewport,
                     })

--- a/webxr/surfman_layer_manager.rs
+++ b/webxr/surfman_layer_manager.rs
@@ -6,8 +6,9 @@
 
 use crate::gl_utils::GlClearer;
 use euclid::{Point2D, Rect, Size2D};
-use sparkle::gl::{self, GLuint, Gl};
+use glow::{self as gl, Context as Gl, HasContext};
 use std::collections::HashMap;
+use std::num::NonZeroU32;
 use surfman::chains::{PreserveBuffer, SwapChains, SwapChainsAPI};
 use surfman::{Context as SurfmanContext, Device as SurfmanDevice, SurfaceAccess, SurfaceTexture};
 use webxr_api::{
@@ -28,7 +29,7 @@ pub struct SurfmanLayerManager {
     layers: Vec<(ContextId, LayerId)>,
     swap_chains: SwapChains<LayerId, SurfmanDevice>,
     surface_textures: HashMap<LayerId, SurfaceTexture>,
-    depth_stencil_textures: HashMap<LayerId, GLuint>,
+    depth_stencil_textures: HashMap<LayerId, Option<gl::NativeTexture>>,
     viewports: Viewports,
     clearer: GlClearer,
 }
@@ -74,19 +75,21 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
             let gl = contexts
                 .bindings(device, context_id)
                 .ok_or(Error::NoMatchingDevice)?;
-            let depth_stencil_texture = gl.gen_textures(1)[0];
-            gl.bind_texture(gl::TEXTURE_2D, depth_stencil_texture);
-            gl.tex_image_2d(
-                gl::TEXTURE_2D,
-                0,
-                gl::DEPTH24_STENCIL8 as _,
-                size.width,
-                size.height,
-                0,
-                gl::DEPTH_STENCIL,
-                gl::UNSIGNED_INT_24_8,
-                gl::TexImageSource::Pixels(None),
-            );
+            let depth_stencil_texture = unsafe { gl.create_texture().ok() };
+            unsafe {
+                gl.bind_texture(gl::TEXTURE_2D, depth_stencil_texture);
+                gl.tex_image_2d(
+                    gl::TEXTURE_2D,
+                    0,
+                    gl::DEPTH24_STENCIL8 as _,
+                    size.width,
+                    size.height,
+                    0,
+                    gl::DEPTH_STENCIL,
+                    gl::UNSIGNED_INT_24_8,
+                    None,
+                );
+            }
             self.depth_stencil_textures
                 .insert(layer_id, depth_stencil_texture);
         }
@@ -118,7 +121,11 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
         self.surface_textures.remove(&layer_id);
         if let Some(depth_stencil_texture) = self.depth_stencil_textures.remove(&layer_id) {
             let gl = contexts.bindings(device, context_id).unwrap();
-            gl.delete_textures(&[depth_stencil_texture]);
+            if let Some(depth_stencil_texture) = depth_stencil_texture {
+                unsafe {
+                    gl.delete_texture(depth_stencil_texture);
+                }
+            }
         }
     }
 
@@ -148,12 +155,16 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
                     .map_err(|_| Error::NoMatchingDevice)?;
                 let color_texture = device.surface_texture_object(&surface_texture);
                 let color_target = device.surface_gl_texture_target();
-                let depth_stencil_texture = self.depth_stencil_textures.get(&layer_id).cloned();
+                let depth_stencil_texture = self
+                    .depth_stencil_textures
+                    .get(&layer_id)
+                    .cloned()
+                    .flatten();
                 let texture_array_index = None;
                 let origin = Point2D::new(0, 0);
                 let sub_image = Some(SubImage {
                     color_texture,
-                    depth_stencil_texture,
+                    depth_stencil_texture: depth_stencil_texture.map(|nt| nt.0.get()),
                     texture_array_index,
                     viewport: Rect::new(origin, surface_size),
                 });
@@ -163,7 +174,7 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
                     .iter()
                     .map(|&viewport| SubImage {
                         color_texture,
-                        depth_stencil_texture,
+                        depth_stencil_texture: depth_stencil_texture.map(|nt| nt.0.get()),
                         texture_array_index,
                         viewport,
                     })
@@ -174,7 +185,7 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
                     contexts,
                     context_id,
                     layer_id,
-                    color_texture,
+                    NonZeroU32::new(color_texture).map(gl::NativeTexture),
                     color_target,
                     depth_stencil_texture,
                 );
@@ -197,7 +208,9 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
             let gl = contexts
                 .bindings(device, context_id)
                 .ok_or(Error::NoMatchingDevice)?;
-            gl.flush();
+            unsafe {
+                gl.flush();
+            }
             let context = contexts
                 .context(device, context_id)
                 .ok_or(Error::NoMatchingDevice)?;


### PR DESCRIPTION
[sparkle](https://github.com/servo/sparkle) is servo owned (but mostly unmaintained) gl create that we would like to archive and replace with [glow](https://github.com/grovesNL/glow/tree/main), that is actively maintained and used by wgpu and wider rust community.

Part of https://github.com/servo/servo/issues/33539